### PR TITLE
Rename Fetch Dataset Tool to Fetch Summary Table

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ To run tests, run `npm run test`.
 ## Available Tools
 This section covers available tools in this MCP Server.
 
-### Fetch Dataset
-A tool for fetching a dataset from the Census Bureau API. Accepts the following parameters:
+### Fetch Summary Table
+The `fetch-summary-table` tool is for fetching a summary table from the Census Bureau API. It accepts the following arguments:
 * Year (Required) - The vintage of the dataset, e.g. 1987
 * Dataset (Required) - The identifier of the dataset, e.g. "acs/acs1"
 * Variables (Required) - The required variables for returning a valid response, e.g. "NAME", "B01001_001E"
@@ -40,7 +40,7 @@ A tool for fetching a dataset from the Census Bureau API. Accepts the following 
 
 #### Example
 ```
-echo '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"fetch-dataset","arguments":{"dataset":"acs/acs1","year":2022,"variables":["NAME","B01001_001E"],"for":"state:01,13"}}}' \
+echo '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"fetch-summary-table","arguments":{"dataset":"acs/acs1","year":2022,"variables":["NAME","B01001_001E"],"for":"state:01,13"}}}' \
 | docker run --rm -i -e CENSUS_API_KEY=YOUR_API_KEY census-api
 ```
 For more information about the parameters above and all available predicates, review the Census Bureau’s [API documentation](https://www.census.gov/data/developers/guidance/api-user-guide.Core_Concepts.html#list-tab-559651575).

--- a/index.ts
+++ b/index.ts
@@ -12,7 +12,7 @@ import { z } from "zod";
 import { MCPTool, ToolRegistry } from "./tools/base.js";
 
 // Import specific tools
-import { FetchDatasetTool } from "./tools/fetch-dataset.js";
+import { FetchSummaryTableTool } from "./tools/fetch-summary-table.tool.js";
 
 // MCP Server class
 class MCPServer {
@@ -84,7 +84,7 @@ async function main() {
   const mcpServer = new MCPServer("census-api", "0.1.0");
 
   // Register tools here
-  mcpServer.registerTool(new FetchDatasetTool());
+  mcpServer.registerTool(new FetchSummaryTableTool());
 
   const transport = new StdioServerTransport();
   await mcpServer.connect(transport);

--- a/tests/tools/fetch-summary-table.tool.test.ts
+++ b/tests/tools/fetch-summary-table.tool.test.ts
@@ -5,7 +5,7 @@ vi.mock('node-fetch', () => ({
 }));
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { FetchDatasetTool } from '../../tools/fetch-dataset';
+import { FetchSummaryTableTool } from '../../tools/fetch-summary-table.tool';
 import { 
   validateToolStructure, 
   validateResponseStructure,
@@ -15,11 +15,11 @@ import {
   sampleCensusError
 } from '../helpers/test-utils.js';
 
-describe('FetchDatasetTool', () => {
-  let tool: FetchDatasetTool;
+describe('FetchSummaryTableTool', () => {
+  let tool: FetchSummaryTableTool;
 
   beforeEach(() => {
-    tool = new FetchDatasetTool();
+    tool = new FetchSummaryTableTool();
     mockFetch.mockClear();
   });
 
@@ -31,8 +31,8 @@ describe('FetchDatasetTool', () => {
   describe('Tool Configuration', () => {
     it('should have correct tool metadata', () => {
       validateToolStructure(tool);
-      expect(tool.name).toBe('fetch-dataset');
-      expect(tool.description).toBe('Fetch a dataset from the Census Bureau’s API');
+      expect(tool.name).toBe('fetch-summary-table');
+      expect(tool.description).toBe('Fetch a summary table from the Census Bureau’s API');
     });
 
     it('should have valid input schema', () => {

--- a/tools/fetch-summary-table.tool.ts
+++ b/tools/fetch-summary-table.tool.ts
@@ -2,9 +2,9 @@ import { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import { BaseTool } from "./base.js";
 
-export class FetchDatasetTool extends BaseTool {
-  name = "fetch-dataset";
-  description = "Fetch a dataset from the Census Bureau’s API";
+export class FetchSummaryTableTool extends BaseTool {
+  name = "fetch-summary-table";
+  description = "Fetch a summary table from the Census Bureau’s API";
   
   inputSchema: Tool["inputSchema"] = {
     type: "object",
@@ -61,7 +61,6 @@ export class FetchDatasetTool extends BaseTool {
   });
 
   async handler(args: z.infer<typeof this.argsSchema>) {
-    console.log("fetch-dataset tool called");
 
     const apiKey = process.env.CENSUS_API_KEY;
     if (!apiKey) {


### PR DESCRIPTION
Renames the fetch-dataset tool to fetch-summary-table to provide a more descriptive and limited function. This convention will be used to build additional tools for different data types.

* Rename fetch-dataset tool to fetch-summary-table
* Update file naming extention to use .tool for tools
* Update tests to reflect new naming convention
* Update README to reflect naming convention