### PR TITLE
Add Tool-specific Dataset Validation

### DIFF
--- a/schema/validators.ts
+++ b/schema/validators.ts
@@ -1,0 +1,36 @@
+type Dataset = {
+	tool: string;
+	message: string;
+	identifier?: string;
+}
+
+const datasets: Dataset[] = [
+	{
+		tool: "fetch-summary-table",
+		message: "Incompatible dataset. Please use the fetch-summary-table tool."
+	 },
+	 {
+		tool: "fetch-timeseries-data",
+		message: "Incompatible dataset.",
+		identifier: "timeseries"
+	 },
+	 {
+		tool: "fetch-pums-microdata",
+		message: "Incompatible dataset.",
+		identifier: "pums"
+	 },
+	 {
+		tool: "fetch-subject-table",
+		message: "Incompatible dataset.",
+		identifier: "subject"
+	 }
+];
+
+export function datasetValidator(url: string): Dataset {
+
+	const matched = datasets.find((dataset: Dataset) =>
+		dataset.identifier ? url.includes(dataset.identifier) : false
+	);
+
+	return matched ?? datasets.find((dataset: Dataset) => !("identifier" in dataset))!;
+}

--- a/tests/schema/validators.test.ts
+++ b/tests/schema/validators.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { datasetValidator } from '../../schema/validators';
+
+describe('datasetValidator', () => {
+	it('returns the correct tool name', () => {
+		const datasets = ["acs/acs1", "timeseries/data/example", "acs/acs1/pums", "acs/acs1/subject", "unknown/data"]
+
+		expect(datasetValidator(datasets[0]).tool).toBe("fetch-summary-table");
+		expect(datasetValidator(datasets[1]).tool).toBe("fetch-timeseries-data");
+		expect(datasetValidator(datasets[2]).tool).toBe("fetch-pums-microdata");
+		expect(datasetValidator(datasets[3]).tool).toBe("fetch-subject-table");
+		expect(datasetValidator(datasets[4]).tool).toBe("fetch-summary-table");
+	});
+});

--- a/tests/tools/fetch-summary-table.tool.test.ts
+++ b/tests/tools/fetch-summary-table.tool.test.ts
@@ -93,6 +93,29 @@ describe('FetchSummaryTableTool', () => {
       };
       expect(() => tool.argsSchema.parse(validArgs)).not.toThrow();
     });
+
+    it('should accept dataset if tool match', () => {
+      const validArgs = {
+        dataset: "acs/acs1", // should be string
+        year: 2022, // should be number
+        variables: ['B01001_001E']
+      }
+
+      expect(() => tool.argsSchema.parse(validArgs)).not.toThrow();
+    });
+
+    it('should reject dataset if tool mismatch', () => {
+      const invalidArgs = {
+        dataset: "timeseries/data/set", // should be string
+        year: 2022, // should be number
+        variables: ['B01001_001E']
+      }
+
+      const result = tool.validateArgs(invalidArgs);
+
+      expect(() => tool.argsSchema.parse(invalidArgs)).toThrow();
+      expect(result.error.issues[0].message).toContain("Incompatible dataset");
+    });
   });
 
   describe('API Key Handling', () => {


### PR DESCRIPTION
Adds dataset validation logic to the fetch-summary-table tool. Also adds extendable validation logic for future tools to deliver customized error messages when there’s a mismatch between a tool and the requested dataset.

* Create validators file with dataset validation logic
* Update fetch-summary-table tool to include dataset validation logic
* Update tests to include validation logic
* Add validator tests