### PR TITLE
Create Geography Tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ echo '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"describe-d
 | docker run --rm -i -e CENSUS_API_KEY=YOUR_API_KEY census-api
 ```
 
+### Fetch Dataset Geography
+The `fetch-dataset-geography` tool is used for fetching available geography levels for filtering a given dataset. It accepts the following arguments:
+* Dataset (Required) - The identifier of the dataset, e.g. "acs/acs1"
+* Year (Optional) - The vintage of the dataset, e.g. 1987
+
+#### Example
+```
+echo '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"fetch-dataset-geography","arguments":{"dataset":"acs/acs1","year":2022}}}' \
+| docker run --rm -i -e CENSUS_API_KEY=YOUR_API_KEY census-api
+```
+
 ### Fetch Summary Table
 The `fetch-summary-table` tool is used for fetching a summary table from the Census Bureau’s API. It accepts the following arguments:
 * Year (Required) - The vintage of the dataset, e.g. 1987

--- a/data/geography-levels.data.ts
+++ b/data/geography-levels.data.ts
@@ -1,0 +1,226 @@
+export const GeographyLevels = {
+  "United States": { 
+    querySyntax: "us",
+    code: "010",
+    queryExample: "for=us:1",
+    codeType: "FIPS" as const,
+    requiresFIPS: false,
+    isHierarchical: false
+  },
+  "Region": { 
+    querySyntax: "region",
+    code: "020",
+    queryExample: "for=region:1",
+    codeType: "FIPS" as const,
+    requiresFIPS: false,
+    isHierarchical: false
+  },
+  "Division": { 
+    querySyntax: "division",
+    code: "030",
+    queryExample: "for=division:1",
+    codeType: "FIPS" as const,
+    requiresFIPS: false,
+    isHierarchical: false
+  },
+  "State": { 
+    querySyntax: "state",
+    code: "040",
+    queryExample: "for=state:06",
+    codeType: "FIPS" as const,
+    requiresFIPS: true,
+    isHierarchical: false
+  },
+  "County": { 
+    querySyntax: "county",
+    code: "050",
+    queryExample: "for=county:075&in=state:06",
+    codeType: "FIPS" as const,
+    requiresFIPS: true,
+    isHierarchical: true
+  },
+  "County Subdivision": { 
+    querySyntax: "county+subdivision",
+    code: "060",
+    queryExample: "for=county+subdivision:*&in=county:075&in=state:06",
+    codeType: "FIPS" as const,
+    requiresFIPS: true,
+    isHierarchical: true
+  },
+  "Census Tract": { 
+    querySyntax: "tract",
+    code: "140",
+    queryExample: "for=tract:*&in=county:075&in=state:06",
+    codeType: "HYBRID" as const,
+    requiresFIPS: true,
+    isHierarchical: true
+  },
+  "Block Group": { 
+    querySyntax: "block+group",
+    code: "150",
+    queryExample: "for=block+group:*&in=tract:123456&in=county:075&in=state:06",
+    codeType: "HYBRID" as const,
+    requiresFIPS: true,
+    isHierarchical: true
+  },
+  "Census Block": { 
+    querySyntax: "block",
+    code: "155",
+    queryExample: "for=block:*&in=tract:123456&in=county:075&in=state:06",
+    codeType: "HYBRID" as const,
+    requiresFIPS: true,
+    isHierarchical: true
+  },
+  "Place": { 
+    querySyntax: "place",
+    code: "160",
+    queryExample: "for=place:67000&in=state:06",
+    codeType: "FIPS" as const,
+    requiresFIPS: true,
+    isHierarchical: true
+  },
+  "Alaska Native Regional Corporation": { 
+    querySyntax: "alaska+native+regional+corporation",
+    code: "230",
+    queryExample: "for=alaska+native+regional+corporation:*&in=state:02",
+    codeType: "FIPS" as const,
+    requiresFIPS: true,
+    isHierarchical: true
+  },
+  "American Indian Area": { 
+    querySyntax: "american+indian+area/alaska+native+area/hawaiian+home+land",
+    code: "250",
+    queryExample: "for=american+indian+area/alaska+native+area/hawaiian+home+land:*",
+    codeType: "FIPS" as const,
+    requiresFIPS: true,
+    isHierarchical: false
+  },
+  "Metropolitan Statistical Area": { 
+    querySyntax: "metropolitan+statistical+area/micropolitan+statistical+area",
+    code: "310",
+    queryExample: "for=metropolitan+statistical+area/micropolitan+statistical+area:41860",
+    codeType: "FIPS" as const,
+    requiresFIPS: true,
+    isHierarchical: false
+  },
+  "Metropolitan Area Principal City": { 
+    querySyntax: "metropolitan+statistical+area/micropolitan+statistical+area-state-principal+city",
+    code: "312",
+    queryExample: "for=metropolitan+statistical+area/micropolitan+statistical+area-state-principal+city:*&in=metropolitan+statistical+area/micropolitan+statistical+area:41860",
+    codeType: "FIPS" as const,
+    requiresFIPS: true,
+    isHierarchical: true
+  },
+  "Metropolitan Division": { 
+    querySyntax: "metropolitan+statistical+area/micropolitan+statistical+area-metropolitan+division",
+    code: "314",
+    queryExample: "for=metropolitan+statistical+area/micropolitan+statistical+area-metropolitan+division:*&in=metropolitan+statistical+area/micropolitan+statistical+area:41860",
+    codeType: "INCITS" as const,
+    requiresFIPS: true,
+    isHierarchical: true
+  },
+  "Combined Statistical Area": { 
+    querySyntax: "combined+statistical+area",
+    code: "330",
+    queryExample: "for=combined+statistical+area:348",
+    codeType: "FIPS" as const,
+    requiresFIPS: true,
+    isHierarchical: false
+  },
+  "Combined NECTA": { 
+    querySyntax: "combined+new+england+city+and+town+area",
+    code: "335",
+    queryExample: "for=combined+new+england+city+and+town+area:*",
+    codeType: "FIPS" as const,
+    requiresFIPS: true,
+    isHierarchical: false
+  },
+  "New England City and Town Area": { 
+    querySyntax: "new+england+city+and+town+area",
+    code: "350",
+    queryExample: "for=new+england+city+and+town+area:*",
+    codeType: "FIPS" as const,
+    requiresFIPS: true,
+    isHierarchical: false
+  },
+  "NECTA Principal City": { 
+    querySyntax: "new+england+city+and+town+area-state-principal+city",
+    code: "352",
+    queryExample: "for=new+england+city+and+town+area-state-principal+city:*&in=new+england+city+and+town+area:*",
+    codeType: "FIPS" as const,
+    requiresFIPS: true,
+    isHierarchical: true
+  },
+  "NECTA Division": { 
+    querySyntax: "new+england+city+and+town+area-necta+division",
+    code: "355",
+    queryExample: "for=new+england+city+and+town+area-necta+division:*&in=new+england+city+and+town+area:*",
+    codeType: "FIPS" as const,
+    requiresFIPS: true,
+    isHierarchical: true
+  },
+  "Urban Area": { 
+    querySyntax: "urban+area",
+    code: "400",
+    queryExample: "for=urban+area:*",
+    codeType: "CENSUS" as const,
+    requiresFIPS: false,
+    isHierarchical: false
+  },
+  "Congressional District": { 
+    querySyntax: "congressional+district",
+    code: "500",
+    queryExample: "for=congressional+district:12&in=state:06",
+    codeType: "INCITS" as const,
+    requiresFIPS: true,
+    isHierarchical: true
+  },
+  "State Senate District": { 
+    querySyntax: "state+legislative+district+(upper+chamber)",
+    code: "610",
+    queryExample: "for=state+legislative+district+(upper+chamber):*&in=state:06",
+    codeType: "STATE" as const,
+    requiresFIPS: true,
+    isHierarchical: true
+  },
+  "State House District": { 
+    querySyntax: "state+legislative+district+(lower+chamber)",
+    code: "620",
+    queryExample: "for=state+legislative+district+(lower+chamber):*&in=state:06",
+    codeType: "STATE" as const,
+    requiresFIPS: true,
+    isHierarchical: true
+  },
+  "Public Use Microdata Area": { 
+    querySyntax: "public+use+microdata+area",
+    code: "795",
+    queryExample: "for=public+use+microdata+area:*&in=state:06",
+    codeType: "CENSUS" as const,
+    requiresFIPS: true,
+    isHierarchical: true
+  },
+  "Elementary School District": { 
+    querySyntax: "school+district+(elementary)",
+    code: "950",
+    queryExample: "for=school+district+(elementary):*&in=state:06",
+    codeType: "EDUCATION" as const,
+    requiresFIPS: true,
+    isHierarchical: true
+  },
+  "Secondary School District": { 
+    querySyntax: "school+district+(secondary)",
+    code: "960",
+    queryExample: "for=school+district+(secondary):*&in=state:06",
+    codeType: "EDUCATION" as const,
+    requiresFIPS: true,
+    isHierarchical: true
+  },
+  "Unified School District": { 
+    querySyntax: "school+district+(unified)",
+    code: "970",
+    queryExample: "for=school+district+(unified):*&in=state:06",
+    codeType: "EDUCATION" as const,
+    requiresFIPS: true,
+    isHierarchical: true
+  }
+};

--- a/index.ts
+++ b/index.ts
@@ -2,6 +2,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { MCPServer } from "./server.js";
 
 import { DescribeDatasetTool } from "./tools/describe-dataset.tool.js";
+import { FetchDatasetGeographyTool } from "./tools/fetch-dataset-geography.tool.js";
 import { FetchSummaryTableTool } from "./tools/fetch-summary-table.tool.js";
 
 // MCP Server Setup
@@ -10,6 +11,7 @@ async function main() {
 
   // Register tools here
   mcpServer.registerTool(new DescribeDatasetTool());
+  mcpServer.registerTool(new FetchDatasetGeographyTool());
   mcpServer.registerTool(new FetchSummaryTableTool());
 
   const transport = new StdioServerTransport();

--- a/resources/geography-code-documentation.ts
+++ b/resources/geography-code-documentation.ts
@@ -1,0 +1,221 @@
+import { CodeType, ParsedGeographyEntry, ParsedGeographyJson } from '../schema/geography.schema.js';
+
+export const CODE_TYPE_DOCUMENTATION = {
+  FIPS: {
+    name: "Federal Information Processing Series (FIPS)",
+    description: "The most commonly used geographic identifiers in Census data. FIPS codes are hierarchical and standardized across federal agencies.",
+    usage: "Used for states, counties, places, metropolitan areas, and most administrative boundaries.",
+    structure: "Hierarchical - smaller areas include codes for larger areas they nest within",
+    examples: [
+      { code: "06", description: "California (state)", level: "State" },
+      { code: "06075", description: "San Francisco County, CA", level: "County" },
+      { code: "0667000", description: "San Francisco city, CA", level: "Place" }
+    ],
+    queryTips: "Most API queries will use FIPS codes. Format queries as: for=county:075&in=state:06",
+    agencies: ["Census Bureau", "Most federal agencies"],
+    stability: "Very stable - rarely change"
+  },
+
+  GNIS: {
+    name: "Geographic Names Information System",
+    description: "Managed by USGS for geographic features like rivers, mountains, and landmarks. Non-hierarchical sequential codes.",
+    usage: "Used for natural and cultural features that don't fit administrative boundaries.",
+    structure: "Sequential assignment based on entry date - no hierarchical relationship",
+    examples: [
+      { code: "277128", description: "Mississippi River", level: "Physical Feature" },
+      { code: "1779775", description: "Golden Gate Bridge", level: "Cultural Feature" },
+      { code: "253573", description: "Mount Whitney", level: "Physical Feature" }
+    ],
+    queryTips: "Less common in Census data APIs. More relevant for geographic mapping services.",
+    agencies: ["US Geological Survey", "US Board on Geographic Names"],
+    stability: "Permanent once assigned"
+  },
+
+  CENSUS: {
+    name: "Census Bureau Statistical Areas",
+    description: "Codes created by Census Bureau for statistical geographic areas not covered by other systems.",
+    usage: "Used for census-specific geographic divisions like tracts, block groups, and urban areas.",
+    structure: "Varies by geography type - some hierarchical, some not",
+    examples: [
+      { code: "06075980100", description: "Census Tract 9801, San Francisco County", level: "Census Tract" },
+      { code: "78904", description: "San Francisco--Oakland, CA Urban Area", level: "Urban Area" },
+      { code: "00106", description: "Pacific Division", level: "Census Division" }
+    ],
+    queryTips: "Often combined with FIPS codes. Tracts require state+county: for=tract:980100&in=county:075&in=state:06",
+    agencies: ["Census Bureau"],
+    stability: "Can change between census cycles"
+  },
+
+  EDUCATION: {
+    name: "Department of Education Local Education Agency (LEA)",
+    description: "Codes assigned by the Department of Education for school districts.",
+    usage: "Used exclusively for elementary, secondary, and unified school districts.",
+    structure: "Hierarchical within states",
+    examples: [
+      { code: "0622710", description: "Los Angeles Unified School District", level: "Unified District" },
+      { code: "0611460", description: "Fremont Union High School District", level: "Secondary District" },
+      { code: "0639390", description: "Alvord Elementary School District", level: "Elementary District" }
+    ],
+    queryTips: "Query as: for=school+district+(unified):*&in=state:06",
+    agencies: ["Department of Education"],
+    stability: "Can change due to district consolidations/splits"
+  },
+
+  STATE: {
+    name: "State-Assigned Codes",
+    description: "Codes assigned by individual states for their internal administrative divisions.",
+    usage: "Used for voting districts, state legislative districts, and other state-defined areas.",
+    structure: "Varies by state - typically hierarchical within state",
+    examples: [
+      { code: "001", description: "California Assembly District 1", level: "State House District" },
+      { code: "040", description: "California Senate District 40", level: "State Senate District" },
+      { code: "000123", description: "Los Angeles County Voting District 123", level: "Voting District" }
+    ],
+    queryTips: "Always require state context: for=state+legislative+district+(upper+chamber):040&in=state:06",
+    agencies: ["Individual state governments"],
+    stability: "Changes with redistricting (every 10 years)"
+  },
+
+  INCITS: {
+    name: "InterNational Committee for Information Technology Standards",
+    description: "Modern replacement for some FIPS codes, managed by ANSI standards organization.",
+    usage: "Used for metropolitan divisions and congressional districts after 2008 FIPS withdrawal.",
+    structure: "Hierarchical, follows FIPS patterns but under new management",
+    examples: [
+      { code: "31084", description: "San Francisco-Redwood City-South San Francisco, CA Metro Division", level: "Metropolitan Division" },
+      { code: "0612", description: "California 12th Congressional District", level: "Congressional District" }
+    ],
+    queryTips: "Similar to FIPS usage: for=congressional+district:12&in=state:06",
+    agencies: ["ANSI via INCITS committee"],
+    stability: "Congressional districts change every 10 years with redistricting"
+  },
+
+  HYBRID: {
+    name: "Combined Code Systems (GEOIDs)",
+    description: "Geographic identifiers that combine multiple coding systems into a single comprehensive ID.",
+    usage: "Used for small geographic areas that nest within multiple larger areas.",
+    structure: "Hierarchical combination of FIPS + Census codes",
+    examples: [
+      { code: "060750001001", description: "Block Group 1, Census Tract 1, San Francisco County", level: "Block Group" },
+      { code: "060750001001001", description: "Census Block 1001 in above block group", level: "Census Block" }
+    ],
+    queryTips: "Often need to specify multiple geographic levels: for=block+group:1&in=tract:000100&in=county:075&in=state:06",
+    agencies: ["Census Bureau combining multiple systems"],
+    stability: "Most stable part (FIPS) rarely changes, Census parts can change"
+  }
+} as const;
+
+/**
+ * Helper function to get documentation for a specific code type
+ */
+export function getCodeTypeDocumentation(codeType: CodeType) {
+  return CODE_TYPE_DOCUMENTATION[codeType];
+}
+
+/**
+ * Generate human-readable explanation for geography entry
+ */
+export function explainGeographyEntry(entry: ParsedGeographyEntry): string {
+  const doc = getCodeTypeDocumentation(entry.codeType);
+  
+  let explanation = `**${entry.fullName}** (Code: ${entry.code})\n\n`;
+  
+  explanation += `**Code Type:** ${doc.name}\n`;
+  explanation += `${doc.description}\n\n`;
+  
+  explanation += `**Usage:** ${doc.usage}\n\n`;
+  
+  if (entry.requiresFIPS) {
+    explanation += `**⚠️  Requires FIPS codes** for API queries\n`;
+  } else {
+    explanation += `**✅ No FIPS codes required** for basic queries\n`;
+  }
+  
+  if (entry.isHierarchical) {
+    explanation += `**🏗️ Hierarchical** - nests within: ${entry.hierarchy.slice(0, -1).join(' → ')}\n`;
+  } else {
+    explanation += `**🎯 Non-hierarchical** - standalone geographic level\n`;
+  }
+  
+  explanation += `\n**Query Tips:** ${doc.queryTips}\n`;
+  
+  return explanation;
+}
+
+/**
+ * Generate summary of all code types available in a geography response
+ */
+export function summarizeAvailableCodeTypes(geography: ParsedGeographyJson): string {
+  const codeTypeCounts = geography.reduce((acc, entry) => {
+    acc[entry.codeType] = (acc[entry.codeType] || 0) + 1;
+    return acc;
+  }, {} as Record<CodeType, number>);
+  
+  let summary = "## Available Geographic Code Types\n\n";
+  
+  Object.entries(codeTypeCounts).forEach(([codeType, count]) => {
+    const doc = CODE_TYPE_DOCUMENTATION[codeType as CodeType];
+    summary += `### ${doc.name} (${count} geographies)\n`;
+    summary += `${doc.description}\n`;
+    summary += `*Managed by: ${doc.agencies.join(', ')}*\n\n`;
+  });
+  
+  const fipsRequired = geography.filter(g => g.requiresFIPS).length;
+  const hierarchical = geography.filter(g => g.isHierarchical).length;
+  
+  summary += `## Quick Stats\n`;
+  summary += `- **${fipsRequired}/${geography.length}** geographies require FIPS codes\n`;
+  summary += `- **${hierarchical}/${geography.length}** geographies are hierarchical\n`;
+  summary += `- **${Object.keys(codeTypeCounts).length}** different code systems in use\n`;
+  
+  return summary;
+}
+
+/**
+ * Tool description that includes code type context
+ */
+export const GEOGRAPHY_TOOL_DESCRIPTION = `
+Fetch available geographic levels for Census datasets. Returns information about:
+
+**Geographic Code Types:**
+- **FIPS**: Standard federal codes (states, counties, places)
+- **GNIS**: Geographic features (rivers, mountains, landmarks)  
+- **CENSUS**: Statistical areas (tracts, block groups, urban areas)
+- **EDUCATION**: School districts (elementary, secondary, unified)
+- **STATE**: State-assigned codes (legislative districts, voting districts)
+- **INCITS**: Modern standards for metro areas, congressional districts
+- **HYBRID**: Combined systems (GEOIDs for small areas)
+
+Each geography includes:
+- Code type and management agency
+- Whether FIPS codes are required for queries
+- Hierarchical relationships
+- Query construction guidance
+
+Use this to understand what geographic levels are available and how to structure API queries for each dataset.
+`.trim();
+
+/**
+ * Error messages with code type context
+ */
+export function createCodeTypeErrorMessage(
+  requestedGeography: string, 
+  availableGeographies: ParsedGeographyJson
+): string {
+  const availableByType = availableGeographies.reduce((acc, geo) => {
+    if (!acc[geo.codeType]) acc[geo.codeType] = [];
+    acc[geo.codeType].push(`${geo.code} (${geo.name})`);
+    return acc;
+  }, {} as Record<CodeType, string[]>);
+  
+  let message = `Geographic level '${requestedGeography}' not available in this dataset.\n\n`;
+  
+  message += "**Available geographies by code type:**\n";
+  Object.entries(availableByType).forEach(([codeType, geos]) => {
+    const doc = CODE_TYPE_DOCUMENTATION[codeType as CodeType];
+    message += `\n**${doc.name}:**\n`;
+    geos.forEach(geo => message += `  - ${geo}\n`);
+  });
+  
+  return message;
+}

--- a/schema/describe-dataset.schema.ts
+++ b/schema/describe-dataset.schema.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 // Input schema for the tool
 export const DescribeDatasetInputSchema = z.object({
   dataset: z.string().describe("Dataset identifier (e.g., 'acs/acs1')"),
-  year: z.number().describe("Data vintage year").optional()
+  year: z.number().describe("Data vintage, e.g. 1987").optional()
 });
 
 // Contact point schema

--- a/schema/geography.schema.ts
+++ b/schema/geography.schema.ts
@@ -1,0 +1,240 @@
+import { z } from 'zod';
+import { GeographyLevels } from '../data/geography-levels.data.js';
+
+/**
+ * Common geography codes enum for validation
+ */
+export const CommonGeographyCodes = z.enum([
+  "010", "020", "030", "040", "050", "060", "140", "150", "155", "160", 
+  "230", "250", "310", "312", "314", "330", "335", "350", "352", "355", 
+  "400", "500", "610", "620", "795", "950", "960", "970"
+]);
+
+export const FetchDatasetGeographyInputSchema = z.object({
+  dataset: z.string().describe("Dataset identifier (e.g., 'acs/acs1')"),
+  year: z.number().describe("The year or vintage of the data, e.g. 1987").optional()
+});
+
+export const FetchDatasetGeographyArgsSchema = {
+  type: "object",
+  properties: {
+    dataset: {
+      type: "string",
+      description: "The dataset identifier (e.g., 'acs/acs1')",
+    },
+    year: {
+      type: "number",
+      description: "The year of the data",
+    }
+  },
+  required: ["dataset"]
+};
+
+/**
+ * Schema for individual geography object in the fips array
+ */
+export const GeographyFipsEntrySchema = z.object({
+  name: z.string().describe("Geography name (e.g., 'state', 'county', 'congressional district')"),
+  geoLevelDisplay: z.string().describe("3-digit geography code (e.g., '040', '050', '500')"),
+  referenceDate: z.string().describe("Reference date (e.g., '2022-01-01')"),
+  requires: z.array(z.string()).optional().describe("Required parent geographies for this level"),
+  wildcard: z.array(z.string()).optional().describe("Geographies that can use wildcards"),
+  optionalWithWCFor: z.string().optional().describe("Optional wildcard geography")
+});
+
+/**
+ * Schema for the actual Census geography.json API response
+ * The API returns an object with a 'fips' array containing geography objects
+ */
+export const GeographyJsonSchema = z.object({
+  fips: z.array(GeographyFipsEntrySchema).describe("Array of available geography levels")
+});
+
+/**
+ * Code type system used for geographic identifiers
+ * Since the geography API always returns FIPS data, we only need FIPS
+ */
+export const CodeTypeSchema = z.literal("FIPS");
+
+/**
+ * Parsed geography entry with structured fields
+ */
+export const ParsedGeographyEntrySchema = z.object({
+  vintage: z.string().describe("Reference date for this geography level"),
+  displayName: z.string().describe("Human-readable display name (e.g., 'State', 'Congressional District')"),
+  querySyntax: z.string().describe("Exact syntax for API queries (e.g., 'state', 'congressional+district')"),
+  code: z.string().describe("3-digit geography level code"),
+  name: z.string().describe("Technical name from API response"),
+  hierarchy: z.array(z.string()).describe("Array of hierarchy levels"),
+  fullName: z.string().describe("Complete geography name"),
+  description: z.string().optional().describe("Additional description if provided"),
+  codeType: CodeTypeSchema.describe("Type of coding system used for this geography"),
+  requiresFIPS: z.boolean().describe("Whether this geography requires FIPS codes for querying"),
+  isHierarchical: z.boolean().describe("Whether this geography has hierarchical relationships"),
+  queryExample: z.string().describe("Example API query syntax"),
+  requires: z.array(z.string()).optional().describe("Required parent geographies"),
+  allowsWildcard: z.array(z.string()).optional().describe("Geographies that support wildcards"),
+  wildcardFor: z.string().optional().describe("Geography this can be wildcarded for")
+});
+
+/**
+ * Parsed geography.json response with structured data
+ */
+export const ParsedGeographyJsonSchema = z.array(ParsedGeographyEntrySchema);
+
+/**
+ * Reverse mappings for lookups
+ */
+const GEOGRAPHY_CODE_TO_DISPLAY: Record<string, string> = Object.fromEntries(
+  Object.entries(GeographyLevels).map(([displayName, metadata]) => [metadata.code, displayName])
+);
+
+type GeoLevelType = {
+  code: string;
+  codeType: string;
+  querySyntax: string;
+  queryExample: string;
+  requiresFIPS: boolean;
+  isHierarchical: boolean;
+}
+
+/**
+ * Get metadata for a geography by its code
+ */
+function getCodeMetadata(code: string) {
+  const displayName = GEOGRAPHY_CODE_TO_DISPLAY[code];
+  if (displayName) {
+    const metadata = (GeographyLevels as Record<string, GeoLevelType>)[displayName];
+    return {
+      displayName,
+      querySyntax: metadata.querySyntax,
+      queryExample: metadata.queryExample,
+      requiresFIPS: metadata.requiresFIPS,
+      isHierarchical: metadata.isHierarchical,
+      codeType: "FIPS" as const // Always FIPS for geography API responses
+    };
+  }
+  
+  return {
+    displayName: `Geography ${code}`,
+    querySyntax: `geography-${code}`,
+    queryExample: `for=geography-${code}:*`,
+    codeType: "FIPS" as const,
+    requiresFIPS: true,
+    isHierarchical: true
+  };
+}
+
+/**
+ * Convert API geography name to query syntax
+ */
+function nameToQuerySyntax(name: string): string {
+  // Handle special cases
+  const specialCases: Record<string, string> = {
+    'american indian area/alaska native area/hawaiian home land': 'american+indian+area/alaska+native+area/hawaiian+home+land',
+    'metropolitan statistical area/micropolitan statistical area': 'metropolitan+statistical+area/micropolitan+statistical+area',
+    'principal city (or part)': 'principal+city+(or+part)',
+    'combined statistical area': 'combined+statistical+area',
+    'combined new england city and town area': 'combined+new+england+city+and+town+area',
+    'new england city and town area': 'new+england+city+and+town+area',
+    'principal city': 'principal+city',
+    'necta division': 'necta+division',
+    'urban area': 'urban+area',
+    'congressional district': 'congressional+district',
+    'public use microdata area': 'public+use+microdata+area',
+    'school district (elementary)': 'school+district+(elementary)',
+    'school district (secondary)': 'school+district+(secondary)',
+    'school district (unified)': 'school+district+(unified)',
+    'county subdivision': 'county+subdivision',
+    'alaska native regional corporation': 'alaska+native+regional+corporation',
+    'metropolitan division': 'metropolitan+division'
+  };
+  
+  return specialCases[name] || name.replace(/\s+/g, '+');
+}
+
+/**
+ * Generate query example based on geography requirements
+ */
+function generateQueryExample(name: string, code: string, requires?: string[]): string {
+  const querySyntax = nameToQuerySyntax(name);
+  
+  if (!requires || requires.length === 0) {
+    return `for=${querySyntax}:*`;
+  }
+  
+  // Handle hierarchical geographies
+  const parentSyntax = requires.map(req => nameToQuerySyntax(req)).join(':*&in=');
+  return `for=${querySyntax}:*&in=${parentSyntax}:*`;
+}
+
+function getDisplayNameFromApiName(apiName: string): string {
+  // Try to find matching display name by checking if the API name matches any query syntax
+  const querySyntax = nameToQuerySyntax(apiName);
+
+  for (const [displayName, metadata] of Object.entries(GeographyLevels)) {
+   if (metadata.querySyntax === querySyntax) {
+     return displayName;
+   }
+  }
+
+  // Fallback: capitalize each word
+  return apiName
+   .split(/[\s]+/)
+   .map(word => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+   .join(' ');
+}
+
+
+/**
+ * Parse raw geography.json response into structured format
+ */
+export function parseGeographyJson(rawGeography: unknown): z.infer<typeof ParsedGeographyJsonSchema> {
+  // Validate the raw response format
+  const validatedRaw = GeographyJsonSchema.parse(rawGeography);
+  
+  // Handle case where fips array is empty
+  if (validatedRaw.fips.length === 0) {
+    console.log('No FIPS geography data found in response');
+    return [];
+  }
+  
+  // Transform each fips entry into our structured format
+  const parsed = validatedRaw.fips.map((entry) => {
+    const displayName = getDisplayNameFromApiName(entry.name);
+    const querySyntax = nameToQuerySyntax(entry.name);
+    const codeMetadata = getCodeMetadata(entry.geoLevelDisplay);
+    const queryExample = generateQueryExample(entry.name, entry.geoLevelDisplay, entry.requires);
+    
+    return {
+      vintage: entry.referenceDate,
+      displayName: displayName,
+      querySyntax: querySyntax,
+      code: entry.geoLevelDisplay,
+      name: entry.name,
+      hierarchy: entry.requires ? [...entry.requires, entry.name] : [entry.name],
+      fullName: displayName,
+      description: undefined,
+      codeType: codeMetadata.codeType,
+      requiresFIPS: codeMetadata.requiresFIPS,
+      isHierarchical: (entry.requires && entry.requires.length > 0) || false,
+      queryExample: queryExample,
+      requires: entry.requires,
+      allowsWildcard: entry.wildcard,
+      wildcardFor: entry.optionalWithWCFor
+    };
+  });
+  
+  // Validate the parsed structure
+  return ParsedGeographyJsonSchema.parse(parsed);
+}
+
+/**
+ * Type exports for convenience
+ */
+export type GeographyFipsEntry = z.infer<typeof GeographyFipsEntrySchema>;
+export type GeographyJson = z.infer<typeof GeographyJsonSchema>;
+export type ParsedGeographyEntry = z.infer<typeof ParsedGeographyEntrySchema>;
+export type ParsedGeographyJson = z.infer<typeof ParsedGeographyJsonSchema>;
+export type GeographyCode = z.infer<typeof CommonGeographyCodes>;
+export type CodeType = z.infer<typeof CodeTypeSchema>;

--- a/schema/summary-table.schema.ts
+++ b/schema/summary-table.schema.ts
@@ -7,7 +7,7 @@ export const SummaryTableSchema = {
     },
     year: {
       type: "number",
-      description: "The year of the data",
+      description: "The year or vintage of the data, e.g. 1987",
     },
     variables: {
       type: "array",

--- a/tests/helpers/test-data.ts
+++ b/tests/helpers/test-data.ts
@@ -1,3 +1,205 @@
+export const sampleGeographyResponse = {
+  "fips": [
+    {
+      "name": "us",
+      "geoLevelDisplay": "010",
+      "referenceDate": "2022-01-01"
+    },
+    {
+      "name": "region",
+      "geoLevelDisplay": "020",
+      "referenceDate": "2022-01-01"
+    },
+    {
+      "name": "division",
+      "geoLevelDisplay": "030",
+      "referenceDate": "2022-01-01"
+    },
+    {
+      "name": "state",
+      "geoLevelDisplay": "040",
+      "referenceDate": "2022-01-01"
+    },
+    {
+      "name": "county",
+      "geoLevelDisplay": "050",
+      "referenceDate": "2022-01-01",
+      "requires": [
+        "state"
+      ],
+      "wildcard": [
+        "state"
+      ],
+      "optionalWithWCFor": "state"
+    },
+    {
+      "name": "county subdivision",
+      "geoLevelDisplay": "060",
+      "referenceDate": "2022-01-01",
+      "requires": [
+        "state",
+        "county"
+      ],
+      "wildcard": [
+        "county"
+      ],
+      "optionalWithWCFor": "county"
+    },
+    {
+      "name": "place",
+      "geoLevelDisplay": "160",
+      "referenceDate": "2022-01-01",
+      "requires": [
+        "state"
+      ],
+      "wildcard": [
+        "state"
+      ],
+      "optionalWithWCFor": "state"
+    },
+    {
+      "name": "alaska native regional corporation",
+      "geoLevelDisplay": "230",
+      "referenceDate": "2022-01-01",
+      "requires": [
+        "state"
+      ],
+      "wildcard": [
+        "state"
+      ],
+      "optionalWithWCFor": "state"
+    },
+    {
+      "name": "american indian area/alaska native area/hawaiian home land",
+      "geoLevelDisplay": "250",
+      "referenceDate": "2022-01-01"
+    },
+    {
+      "name": "metropolitan statistical area/micropolitan statistical area",
+      "geoLevelDisplay": "310",
+      "referenceDate": "2022-01-01"
+    },
+    {
+      "name": "principal city (or part)",
+      "geoLevelDisplay": "312",
+      "referenceDate": "2022-01-01",
+      "requires": [
+        "metropolitan statistical area/micropolitan statistical area",
+        "state (or part)"
+      ]
+    },
+    {
+      "name": "metropolitan division",
+      "geoLevelDisplay": "314",
+      "referenceDate": "2022-01-01",
+      "requires": [
+        "metropolitan statistical area/micropolitan statistical area"
+      ]
+    },
+    {
+      "name": "combined statistical area",
+      "geoLevelDisplay": "330",
+      "referenceDate": "2022-01-01"
+    },
+    {
+      "name": "combined new england city and town area",
+      "geoLevelDisplay": "335",
+      "referenceDate": "2022-01-01"
+    },
+    {
+      "name": "new england city and town area",
+      "geoLevelDisplay": "350",
+      "referenceDate": "2022-01-01"
+    },
+    {
+      "name": "principal city",
+      "geoLevelDisplay": "352",
+      "referenceDate": "2022-01-01",
+      "requires": [
+        "new england city and town area",
+        "state (or part)"
+      ],
+      "wildcard": [
+        "state (or part)"
+      ],
+      "optionalWithWCFor": "state (or part)"
+    },
+    {
+      "name": "necta division",
+      "geoLevelDisplay": "355",
+      "referenceDate": "2022-01-01",
+      "requires": [
+        "new england city and town area"
+      ]
+    },
+    {
+      "name": "urban area",
+      "geoLevelDisplay": "400",
+      "referenceDate": "2022-01-01"
+    },
+    {
+      "name": "congressional district",
+      "geoLevelDisplay": "500",
+      "referenceDate": "2022-01-01",
+      "requires": [
+        "state"
+      ],
+      "wildcard": [
+        "state"
+      ],
+      "optionalWithWCFor": "state"
+    },
+    {
+      "name": "public use microdata area",
+      "geoLevelDisplay": "795",
+      "referenceDate": "2022-01-01",
+      "requires": [
+        "state"
+      ],
+      "wildcard": [
+        "state"
+      ],
+      "optionalWithWCFor": "state"
+    },
+    {
+      "name": "school district (elementary)",
+      "geoLevelDisplay": "950",
+      "referenceDate": "2022-01-01",
+      "requires": [
+        "state"
+      ],
+      "wildcard": [
+        "state"
+      ],
+      "optionalWithWCFor": "state"
+    },
+    {
+      "name": "school district (secondary)",
+      "geoLevelDisplay": "960",
+      "referenceDate": "2022-01-01",
+      "requires": [
+        "state"
+      ],
+      "wildcard": [
+        "state"
+      ],
+      "optionalWithWCFor": "state"
+    },
+    {
+      "name": "school district (unified)",
+      "geoLevelDisplay": "970",
+      "referenceDate": "2022-01-01",
+      "requires": [
+        "state"
+      ],
+      "wildcard": [
+        "state"
+      ],
+      "optionalWithWCFor": "state"
+    }
+  ]
+};
+
 export const mockMetadataResponse = {
   "@context": "https://project-open-data.cio.gov/v1.1/schema/catalog.jsonld",
   "@id": "http://api.census.gov/data/2022/acs/acs1.json",

--- a/tests/tools/fetch-dataset-geography/fetch-dataset-geography.tool.test.ts
+++ b/tests/tools/fetch-dataset-geography/fetch-dataset-geography.tool.test.ts
@@ -1,0 +1,214 @@
+const mockFetch = vi.fn();
+
+vi.mock('node-fetch', () => ({
+	default: mockFetch
+}));
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { FetchDatasetGeographyTool } from '../../../tools/fetch-dataset-geography.tool';
+import { 
+  validateJsonResponseStructure,
+  validateToolStructure, 
+  validateResponseStructure,
+  createMockResponse,
+  createMockFetchError,
+  sampleCensusError
+} from '../../helpers/test-utils.js';
+
+import { sampleGeographyResponse } from '../../helpers/test-data.js';
+
+describe('FetchGeographyDatasetTool', () => {
+  let tool: FetchGeographyDatasetTool;
+
+  beforeEach(() => {
+    tool = new FetchDatasetGeographyTool();
+    mockFetch.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  describe('Tool Configuration', () => {
+    it('should have correct tool metadata', () => {
+      validateToolStructure(tool);
+      expect(tool.name).toBe('fetch-dataset-geography');
+      expect(tool.description).toBe("Fetch available geographies for filtering a dataset.");
+    });
+
+    it('should have valid input schema', () => {
+      const schema = tool.inputSchema;
+      expect(schema.type).toBe('object');
+      expect(schema.properties).toHaveProperty('dataset');
+      expect(schema.properties).toHaveProperty('year');
+      expect(schema.required).toEqual(['dataset']);
+    });
+
+    it('should have matching args schema', () => {
+      // Test required fields
+      const validArgs = {
+        dataset: 'acs/acs1',
+        year: 2022
+      };
+      expect(() => tool.argsSchema.parse(validArgs)).not.toThrow();
+    });
+  });
+
+  describe('Schema Validation', () => {
+    it('should validate required parameters', () => {
+      const incompleteArgs = { year: 2024 }; // missing dataset
+      expect(() => tool.argsSchema.parse(incompleteArgs)).toThrow();
+    });
+
+    it('should validate parameter types', () => {
+      const invalidArgs = {
+        dataset: 123, // should be string
+        year: '2022', // should be number
+      };
+      expect(() => tool.argsSchema.parse(invalidArgs)).toThrow();
+    });
+
+    it('should accept valid optional parameters', () => {
+      const validArgs = {
+        dataset: 'acs/acs1',
+        year: 2022
+      };
+      expect(() => tool.argsSchema.parse(validArgs)).not.toThrow();
+    });
+  });
+
+  describe('API Key Handling', () => {
+    it('should return error when API key is missing', async () => {
+      const originalApiKey = process.env.CENSUS_API_KEY;
+      delete process.env.CENSUS_API_KEY;
+
+      const args = {
+        dataset: 'acs/acs1',
+        year: 2022
+      };
+
+      const response = await tool.handler(args);
+      validateResponseStructure(response);
+      expect(response.content[0].text).toContain('CENSUS_API_KEY is not set');
+
+      // Restore API key
+      process.env.CENSUS_API_KEY = originalApiKey;
+    });
+
+    it('should use API key when available', async () => {
+      mockFetch.mockResolvedValue(createMockResponse(sampleGeographyResponse));
+
+      const args = {
+        dataset: 'acs/acs1',
+        year: 2022
+      };
+
+      await tool.handler(args);
+      
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('key=')
+      );
+    });
+  });
+
+  describe('URL Construction', () => {
+    it('should construct basic URL correctly', async () => {
+
+      const args = {
+        dataset: 'acs/acs1',
+        year: 2022
+      };
+
+      await tool.handler(args);
+      const calls = mockFetch.mock.calls;
+      expect(calls[0][0]).toContain('https://api.census.gov/data/2022/acs/acs1/geography.json?key=');
+    });
+
+    it('should construct URL without year for timeseries', async () => {
+      mockFetch.mockResolvedValue(createMockResponse(sampleGeographyResponse));
+
+      const args = {
+        dataset: 'timeseries/asm/area2012'
+      };
+
+      await tool.handler(args);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('https://api.census.gov/data/timeseries/asm/area2012/geography.json?key=')
+      );
+    });
+  });
+
+  describe('API Response Handling', () => {
+    it('should handle successful API response', async () => {
+      mockFetch.mockResolvedValue(createMockResponse(sampleGeographyResponse));
+
+      const args = {
+        dataset: 'acs/acs1',
+        year: 2022
+      };
+
+      const response = await tool.handler(args);
+      validateJsonResponseStructure(response);
+      
+      // Since you changed to JSON response, check for JSON content
+      expect(response.content[0].type).toBe('json');
+
+      const responseData = response.content[0].json;
+	 
+		  expect(Array.isArray(responseData)).toBe(true);
+		  expect(responseData.length).toBeGreaterThan(0);
+		  
+		  const firstGeography = responseData[0];
+		  expect(firstGeography).toHaveProperty('code'); // or whatever properties your geography objects have
+		  expect(firstGeography).toHaveProperty('name'); // adjust to match your actual structure
+		  expect(firstGeography).toHaveProperty('displayName'); // adjust to match your actual structure
+ 
+    });
+
+    it('should handle API error responses', async () => {
+      mockFetch.mockResolvedValue(createMockResponse(sampleCensusError, 400, 'Bad Request'));
+
+      const args = {
+        dataset: 'invalid/dataset',
+        year: 2022
+      };
+
+      const response = await tool.handler(args);
+      validateResponseStructure(response);
+      expect(response.content[0].text).toContain(
+        'Geography endpoint returned: 400 Bad Request'
+      );
+    });
+
+    it('should handle network errors', async () => {
+      mockFetch.mockImplementation(() => createMockFetchError('Network error'));
+
+      const args = {
+        dataset: 'acs/acs1',
+        year: 2022
+      };
+
+      const response = await tool.handler(args);
+      validateResponseStructure(response);
+      expect(response.content[0].text).toContain('Failed to fetch dataset metadata: Network error');
+    });
+
+    it('should handle malformed JSON responses', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.reject(new Error('Invalid JSON'))
+      });
+
+      const args = {
+        dataset: 'acs/acs1',
+        year: 2022
+      };
+
+      const response = await tool.handler(args);
+      validateResponseStructure(response);
+      expect(response.content[0].text).toContain('Failed to fetch dataset metadata: Invalid JSON');
+    });
+  });
+});

--- a/tests/tools/fetch-dataset-geography/fetch-dataset.geography.tool.integration.test.ts
+++ b/tests/tools/fetch-dataset-geography/fetch-dataset.geography.tool.integration.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { FetchDatasetGeographyTool } from '../../../tools/fetch-dataset-geography.tool';
+
+describe('FetchDatasetGeographyTool - Integration Tests', () => {
+
+  it('should fetch real ACS metadata', async () => {
+    const tool = new FetchDatasetGeographyTool();
+    const datasetName = 'acs/acs1';
+    
+    const response = await tool.handler({
+      dataset: datasetName,
+      year: 2022
+    });
+
+    expect(response.content[0].type).toBe('json');
+    const data = response.content[0].json;
+
+    const firstGeography = data[0];
+	  expect(firstGeography.vintage).toBe('2022-01-01'); // or whatever properties your geography objects have
+	  expect(firstGeography.displayName).toBe('United States'); // adjust to match your actual structure
+	  expect(firstGeography.querySyntax).toBe('us'); // adjust to match your actual structure
+	  expect(firstGeography.queryExample).toBe('for=us:*');
+  }, 10000); // Longer timeout for real API calls
+
+  it('should handle real API errors gracefully', async () => {
+    const tool = new FetchDatasetGeographyTool();
+    
+    const response = await tool.handler({
+      dataset: 'nonexistent/dataset'
+    });
+
+    expect(response.content[0].type).toBe('text');
+    expect(response.content[0].text).toContain('Geography endpoint returned: 404');
+  }, 10000);
+
+  it('should work with timeseries datasets', async () => {
+    const tool = new FetchDatasetGeographyTool();
+    const datasetName = 'timeseries/healthins/sahie';
+    
+    const response = await tool.handler({
+      dataset: datasetName
+    });
+
+    expect(response.content[0].type).toBe('json');
+  });
+});

--- a/tools/fetch-dataset-geography.tool.ts
+++ b/tools/fetch-dataset-geography.tool.ts
@@ -1,0 +1,85 @@
+import { Tool } from "@modelcontextprotocol/sdk/types.js";
+
+import { BaseTool } from "./base.js";
+import { 
+	FetchDatasetGeographyArgsSchema,
+	FetchDatasetGeographyInputSchema,
+	GeographyJsonSchema,
+	parseGeographyJson
+} from '../schema/geography.schema.js';
+
+import { FetchDatasetGeographyArgs } from '../types/fetch-dataset-geography.types.js';
+import { ToolContent } from '../types/base.types.js';
+
+
+export class FetchDatasetGeographyTool extends BaseTool<FetchDatasetGeographyArgs> {
+  name = "fetch-dataset-geography";
+  description = "Fetch available geographies for filtering a dataset.";
+
+  inputSchema: Tool["inputSchema"] = FetchDatasetGeographyArgsSchema as Tool["inputSchema"];
+
+  get argsSchema() {
+    return FetchDatasetGeographyInputSchema;
+  }
+
+  constructor() {
+    super();
+    this.handler = this.handler.bind(this);
+  }
+
+  async handler(args: FetchDatasetGeographyArgs): Promise<{ content: ToolContent[] }> {
+		try {
+	  	const apiKey = process.env.CENSUS_API_KEY;
+	    if (!apiKey) {
+	      return this.createErrorResponse("Error: CENSUS_API_KEY is not set.");
+	    }
+
+	    const fetch = (await import("node-fetch")).default;
+	    let year = ""; //Start with a blank year
+	    if(args.year){ year = `${args.year}/` } // Add the year if it is present in the input args
+	    
+	    const baseUrl = `https://api.census.gov/data/${year}${args.dataset}/geography.json`; // Construct the URL
+			const geographyUrl = `${baseUrl}?key=${apiKey}`; // Add the API Key
+
+
+		  const geographyResponse = await fetch(geographyUrl);
+
+		  if (geographyResponse.ok) {
+		    const geographyData = await geographyResponse.json();
+
+		    try {
+		    	const validatedData = GeographyJsonSchema.parse(geographyData);
+		    	const parsedGeographyData = parseGeographyJson(validatedData);
+
+		    	return {
+            content: [
+              {
+                type: "json" as const,
+                json: parsedGeographyData
+              }
+            ]
+          };
+		    } catch (validationError) {
+          // If validation fails, return the error details
+          const validationMessage = validationError instanceof Error ? validationError.message : 'Validation failed';
+          console.error('Schema validation failed:', validationMessage);
+          
+          return this.createErrorResponse(
+            `Response validation failed: ${validationMessage}`
+          );
+        }
+		  } else {
+		  	console.log(geographyResponse.status);
+		    return this.createErrorResponse(
+        `Geography endpoint returned: ${geographyResponse.status} ${geographyResponse.statusText}`
+      );
+		  }
+		} catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
+      
+      return this.createErrorResponse(
+        `Failed to fetch dataset metadata: ${errorMessage}`
+      );
+    }
+  }
+}

--- a/types/fetch-dataset-geography.types.ts
+++ b/types/fetch-dataset-geography.types.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+import {
+	FetchDatasetGeographyInputSchema
+} from '../schema/geography.schema.js'
+
+export type FetchDatasetGeographyArgs = z.infer<typeof FetchDatasetGeographyInputSchema>;


### PR DESCRIPTION
Introduces the fetch-dataset-geography tool for fetching the available geographic levels that a dataset can be filtered by.

* Create fetch-dataset-geography tool
* Create a geography schema for validated input, validating API responses, and parsing each response.
* Update test data to include sample geography data
* Add tests for fetch-dataset-geography-tool