### PR TITLE
Suppress Logging by Default

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,15 @@ Then run `npm run build` to build the project.
 
 With Docker desktop running, run `npm run docker-build` to build the project in Docker.
 
+## Development
+
+By default, all logging functions are disabled to prevent `json` validation errors when interacting with the MCP server through MCP clients. To enable logging for development purposes, set `DEBUG_LOGS=true` when running the server in Docker, e.g. `-e DEBUG_LOGS=true`. 
+
 ### Testing
 
 This project uses [Vitest](https://vitest.dev/) to test the functionality of the server.
+
+Prior to running tests, a valid Census Bureau [API key](https://api.census.gov/data/key_signup.html) is required. This key should be defined in the `.env` file of the root directory of the project. The `sample.env` offers an example of how this `.env` file should look. Note that the `.env` is unique 
 
 To run tests, run `npm run test`. To run ESLint, run `npm run lint`.
 

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,11 @@
+const enableDebugLogs = process.env.DEBUG_LOGS === 'true';
+
+if(!enableDebugLogs) {
+  console.log = () => {};
+  console.info = () => {};
+  console.warn = () => {};
+}
+
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { MCPServer } from "./server.js";
 


### PR DESCRIPTION
Suppresses console.log, console.info, and console.warn by default unless a DEBUG_LOGS environment variable is set to true. This resolves issues running the MCP Server with LLM clients that expect valid JSON responses in all interactions.

* Suppress console.log by default
* Suppress console.info by default
* Suppress console.warn by default
* Add check for DEBUG_LOGS environment variable to enable logging
* Update README documentation to include Development section with DEBUG_LOGS documentation