### PR TITLE
Remove JSON Content Type

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -17,7 +17,9 @@ export class MCPServer {
   constructor(name: string, version: string) {
     this.server = new Server(
       { name, version },
-      { capabilities: { tools: {} } }
+      { capabilities: { tools: {
+
+      } } }
     );
     this.setupHandlers();
   }

--- a/tests/tools/describe-dataset/describe-dataset.tool.integration.test.ts
+++ b/tests/tools/describe-dataset/describe-dataset.tool.integration.test.ts
@@ -12,12 +12,12 @@ describe('DescribeDatasetTool - Integration Tests', () => {
       year: 2022
     });
 
-    expect(response.content[0].type).toBe('json');
-    const data = response.content[0].json;
-    expect(data).toHaveProperty('@type', 'DatasetMetadata');
-    expect(data.dataset.title).toContain('American Community Survey');
-    expect(data.dataset.api.endpoint).toBe(`http://api.census.gov/data/2022/${datasetName}`);
-    expect(data.source).toBe('dataset endpoint');
+    expect(response.content[0].type).toBe('text');
+    const responseText = response.content[0].text;
+    expect(responseText).toContain('"@type": "DatasetMetadata"');
+    expect(responseText).toContain('American Community Survey');
+    expect(responseText).toContain(`http://api.census.gov/data/2022/${datasetName}`);
+    expect(responseText).toContain('dataset endpoint');
   }, 10000); // Longer timeout for real API calls
 
   it('should handle real API errors gracefully', async () => {
@@ -39,9 +39,9 @@ describe('DescribeDatasetTool - Integration Tests', () => {
       dataset: datasetName
     });
 
-    expect(response.content[0].type).toBe('json');
-    const data = response.content[0].json;
-    expect(data).toHaveProperty('@type', 'DatasetMetadata');
-    expect(data.dataset.api.endpoint).toBe(`http://api.census.gov/data/${datasetName}`);
+    expect(response.content[0].type).toBe('text');
+    const responseText = response.content[0].text;
+    expect(responseText).toContain('"@type": "DatasetMetadata"');
+    expect(responseText).toContain(`http://api.census.gov/data/${datasetName}`);
   }, 10000);
 });

--- a/tests/tools/describe-dataset/describe-dataset.tool.test.ts
+++ b/tests/tools/describe-dataset/describe-dataset.tool.test.ts
@@ -7,7 +7,7 @@ vi.mock('node-fetch', () => ({
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { DescribeDatasetTool } from '../../../tools/describe-dataset.tool';
 import { 
-  validateJsonResponseStructure,
+  validateResponseStructure,
   validateToolStructure, 
   validateResponseStructure,
   createMockResponse,
@@ -158,14 +158,13 @@ describe('DescribeDatasetTool', () => {
       };
 
       const response = await tool.handler(args);
-      validateJsonResponseStructure(response);
+      validateResponseStructure(response);
       
       // Since you changed to JSON response, check for JSON content
-      expect(response.content[0].type).toBe('json');
-      const responseData = response.content[0].json;
-      expect(responseData).toHaveProperty('@type', 'DatasetMetadata');
-      expect(responseData.dataset).toHaveProperty('title');
-      expect(responseData.dataset.title).toContain('American Community Survey');
+      expect(response.content[0].type).toBe('text');
+      const responseText = response.content[0].text;
+      expect(responseText).toContain('"@type": "DatasetMetadata"');
+      expect(responseText).toContain('"title": "American Community Survey: 1-Year Estimates: Detailed Tables"');
     });
 
     it('should handle API error responses', async () => {

--- a/tests/tools/fetch-dataset-geography/fetch-dataset-geography.tool.test.ts
+++ b/tests/tools/fetch-dataset-geography/fetch-dataset-geography.tool.test.ts
@@ -7,7 +7,7 @@ vi.mock('node-fetch', () => ({
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { FetchDatasetGeographyTool } from '../../../tools/fetch-dataset-geography.tool';
 import { 
-  validateJsonResponseStructure,
+  validateResponseStructure,
   validateToolStructure, 
   validateResponseStructure,
   createMockResponse,
@@ -150,20 +150,16 @@ describe('FetchGeographyDatasetTool', () => {
       };
 
       const response = await tool.handler(args);
-      validateJsonResponseStructure(response);
+      validateResponseStructure(response);
       
       // Since you changed to JSON response, check for JSON content
-      expect(response.content[0].type).toBe('json');
+      expect(response.content[0].type).toBe('text');
 
-      const responseData = response.content[0].json;
-	 
-		  expect(Array.isArray(responseData)).toBe(true);
-		  expect(responseData.length).toBeGreaterThan(0);
+      const responseText = response.content[0].text;
 		  
-		  const firstGeography = responseData[0];
-		  expect(firstGeography).toHaveProperty('code'); // or whatever properties your geography objects have
-		  expect(firstGeography).toHaveProperty('name'); // adjust to match your actual structure
-		  expect(firstGeography).toHaveProperty('displayName'); // adjust to match your actual structure
+		  expect(responseText).toContain('code'); // or whatever properties your geography objects have
+		  expect(responseText).toContain('name'); // adjust to match your actual structure
+		  expect(responseText).toContain('displayName'); // adjust to match your actual structure
  
     });
 

--- a/tests/tools/fetch-dataset-geography/fetch-dataset.geography.tool.integration.test.ts
+++ b/tests/tools/fetch-dataset-geography/fetch-dataset.geography.tool.integration.test.ts
@@ -12,14 +12,13 @@ describe('FetchDatasetGeographyTool - Integration Tests', () => {
       year: 2022
     });
 
-    expect(response.content[0].type).toBe('json');
-    const data = response.content[0].json;
+    expect(response.content[0].type).toBe('text');
+    const responseText = response.content[0].text;
 
-    const firstGeography = data[0];
-	  expect(firstGeography.vintage).toBe('2022-01-01'); // or whatever properties your geography objects have
-	  expect(firstGeography.displayName).toBe('United States'); // adjust to match your actual structure
-	  expect(firstGeography.querySyntax).toBe('us'); // adjust to match your actual structure
-	  expect(firstGeography.queryExample).toBe('for=us:*');
+	  expect(responseText).toContain('"vintage": "2022-01-01"'); // or whatever properties your geography objects have
+	  expect(responseText).toContain('"displayName": "United States"'); // adjust to match your actual structure
+	  expect(responseText).toContain('"querySyntax": "us"'); // adjust to match your actual structure
+	  expect(responseText).toContain('"queryExample": "for=us:*"');
   }, 10000); // Longer timeout for real API calls
 
   it('should handle real API errors gracefully', async () => {
@@ -41,6 +40,6 @@ describe('FetchDatasetGeographyTool - Integration Tests', () => {
       dataset: datasetName
     });
 
-    expect(response.content[0].type).toBe('json');
+    expect(response.content[0].type).toBe('text');
   });
 });

--- a/tools/describe-dataset.tool.ts
+++ b/tools/describe-dataset.tool.ts
@@ -272,8 +272,8 @@ export class DescribeDatasetTool extends BaseTool<DescribeDatasetArgs> {
           return {
             content: [
               {
-                type: "json" as const,
-                json: validatedResponse
+                type: "text",
+                text: `Metadata for ${args.dataset}${args.year ? ` (${args.year})` : ''}:\n\n${JSON.stringify(validatedResponse, null, 2)}`
               }
             ]
           };

--- a/tools/fetch-dataset-geography.tool.ts
+++ b/tools/fetch-dataset-geography.tool.ts
@@ -54,8 +54,8 @@ export class FetchDatasetGeographyTool extends BaseTool<FetchDatasetGeographyArg
 		    	return {
             content: [
               {
-                type: "json" as const,
-                json: parsedGeographyData
+                type: "text",
+                text: `Available geographies for ${args.dataset}${args.year ? ` (${args.year})` : ''}:\n\n${JSON.stringify(parsedGeographyData, null, 2)}`
               }
             ]
           };


### PR DESCRIPTION
The MCP standard does not support JSON content type responses. JSON should be formatted as text instead. This commit updates the describe-dataset-tool and fetch-dataset-geography-tool to use the text content type instead.

* Replace json content type with text in describe-data-tool
* Replace json content type with text in fetch-dataset-geography-tool