### PR TITLE
Return Variable Names Only in Fetch Dataset Variables

### DIFF
--- a/schema/dataset-variables.schema.ts
+++ b/schema/dataset-variables.schema.ts
@@ -202,9 +202,10 @@ export function getFilteredVariables(
     );
   }
 
+  // Filter by excluded predicate types
   if (options.excludePredicateTypes?.length) {
     filtered = filtered.filter(([, variable]) => 
-      variable.predicateType && options.includePredicateTypes!.includes(variable.predicateType)
+      !variable.predicateType || !options.excludePredicateTypes!.includes(variable.predicateType)
     );
   }
 

--- a/tests/tools/fetch-dataset-variables/fetch-dataset-variables.tool.integration.test.ts
+++ b/tests/tools/fetch-dataset-variables/fetch-dataset-variables.tool.integration.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import { FetchDatasetVariablesTool } from '../../../tools/fetch-dataset-variables.tool';
-import { VariableBasic } from '../../../schema/dataset-variables.schema';
 
 interface CensusDataset {
   c_vintage?: number;
@@ -164,17 +163,10 @@ describe('FetchDatasetVariablesTool - Integration Tests', () => {
           expect(Array.isArray(variables)).toBe(true);
           expect(variables.length).toBe(variableCount);
           
-          variables.forEach((variable: VariableBasic, index: number) => {
-            expect(variable).toHaveProperty('name');
-            expect(variable).toHaveProperty('label');
-            expect(typeof variable.name).toBe('string');
-            expect(typeof variable.label).toBe('string');
-            expect(variable.name.length).toBeGreaterThan(0);
-            expect(variable.label.length).toBeGreaterThan(0);
-            
-            if (index < 3) {
-              console.log(`  Variable ${index + 1}: ${variable.name} - ${variable.label}`);
-            }
+          // FIX: Each variable should be a string, not an object
+          variables.forEach((variable: string) => {
+            expect(typeof variable).toBe('string');
+            expect(variable.length).toBeGreaterThan(0); // Should be non-empty string
           });
 
           results.push({

--- a/tools/fetch-dataset-variables.tool.ts
+++ b/tools/fetch-dataset-variables.tool.ts
@@ -2,7 +2,7 @@ import { Tool } from "@modelcontextprotocol/sdk/types.js";
 
 import { BaseTool } from "./base.tool.js";
 import { 
-	getVariableBasics,
+	getVariableNamesOnly,
 	FetchDatasetVariablesArgs,
 	FetchDatasetVariablesArgsSchema,
 	FetchDatasetVariablesInputSchema,
@@ -48,17 +48,17 @@ export class FetchDatasetVariablesTool extends BaseTool<FetchDatasetVariablesArg
 
 		    try {
 		    	const validatedData = VariablesJsonSchema.parse(variablesData);
-		    	const basicVariables = getVariableBasics(validatedData);
+		    	const variableNames = getVariableNamesOnly(validatedData);
 		    	
 		    	// Calculate some useful stats for the LLM
-		    	const totalVariables = basicVariables.length;
+		    	const totalVariables = variableNames.length;
 		    	
 		    	const responseText = [
 		    	  `Dataset: ${args.dataset}${args.year ? ` (${args.year})` : ''}`,
 		    	  `Total Variables: ${totalVariables}`,
 		    	  ``,
 		    	  `Complete variable list:`,
-		    	  JSON.stringify(basicVariables, null, 2)
+		    	  JSON.stringify(variableNames, null, 2)
 		    	].join('\n');
 
 		    	return {


### PR DESCRIPTION
Updates the fetch-dataset-variables tool to return the variable names only for a given dataset due to the size of the response.

* Update fetch-dataset-variables tool response to call getVariableNamesOnly from the dataset-variables.schema