### PR TITLE
Add Group Argument to Fetch Dataset Variables Tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ This section covers tools that can be called.
 
 ### Describe Dataset
 The `describe-dataset` tool is used for fetching metadata about a given dataset in the Census Bureau’s API. It accepts the following arguments:
-* Dataset (Required) - The identifier of the dataset, e.g. "acs/acs1"
-* Year (Optional) - The vintage of the dataset, e.g. 1987
+* Dataset (Required) - The identifier of the dataset, e.g. `'acs/acs1'`
+* Year (Optional) - The vintage of the dataset, e.g. `1987`
 
 #### Example
 ```
@@ -68,8 +68,8 @@ echo '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"describe-d
 
 ### Fetch Dataset Geography
 The `fetch-dataset-geography` tool is used for fetching available geography levels for filtering a given dataset. It accepts the following arguments:
-* Dataset (Required) - The identifier of the dataset, e.g. "acs/acs1"
-* Year (Optional) - The vintage of the dataset, e.g. 1987
+* Dataset (Required) - The identifier of the dataset, e.g. `'acs/acs1'`
+* Year (Optional) - The vintage of the dataset, e.g. `1987`
 
 #### Example
 ```
@@ -79,8 +79,9 @@ echo '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"fetch-data
 
 ### Fetch Dataset Variables
 The `fetch-dataset-variables` tool is used for fetching variables for filtering a given dataset. It accepts the following arguments:
-* Dataset (Required) - The identifier of the dataset, e.g. "acs/acs1"
-* Year (Optional) - The vintage of the dataset, e.g. 1987
+* Dataset (Required) - The identifier of the dataset, e.g. `'acs/acs1'`
+* Group (Optional) - Filter variables by a specific group for this dataset, e.g. `'S0101'`
+* Year (Optional) - The vintage of the dataset, e.g. `1987`
 
 #### Example
 ```
@@ -90,13 +91,13 @@ echo '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"fetch-data
 
 ### Fetch Summary Table
 The `fetch-summary-table` tool is used for fetching a summary table from the Census Bureau’s API. It accepts the following arguments:
-* Year (Required) - The vintage of the dataset, e.g. 1987
-* Dataset (Required) - The identifier of the dataset, e.g. "acs/acs1"
-* Variables (Required) - The required variables for returning a valid response, e.g. "NAME", "B01001_001E"
+* Dataset (Required) - The identifier of the dataset, e.g. `'acs/acs1'`
+* Variables (Required) - The required variables for returning a valid response, e.g. `'NAME'`, `'B01001_001E'`
+* Year (Optional) - The vintage of the dataset, e.g. `1987`
 * For (Optional) - Restricts geography to various levels and is required in most datasets
 * In (Optional) - Restricts geography to smaller areas than state level
-* Predicates (Optional) - Filter options for the dataset, e.g. "for": "state*"
-* Descriptive (Optional) - Add variable labels to API response
+* Predicates (Optional) - Filter options for the dataset, e.g. `'for': 'state*'`
+* Descriptive (Optional) - Add variable labels to API response (default: `false`), e.g. `true`
 * Output Format (Optional) - Specificies CSV or JSON output
 
 #### Example

--- a/schema/dataset-variables.schema.ts
+++ b/schema/dataset-variables.schema.ts
@@ -2,8 +2,10 @@ import { z } from 'zod';
 
 //Argument Validation 
 export const FetchDatasetVariablesInputSchema = z.object({
-  dataset: z.string().describe("Dataset identifier (e.g., 'acs/acs1')"),
-  year: z.number().describe("The year or vintage of the data, e.g. 1987").optional()
+  dataset: z.string().describe("Dataset identifier, e.g. 'acs/acs1'"),
+  group: z.string().describe("Filter variables by a specific group for this dataset, e.g. 'S0101'").optional(),
+  year: z.number().describe("The year or vintage of the data, e.g. 2022").optional(),
+
 });
 
 export const FetchDatasetVariablesArgsSchema = {
@@ -11,12 +13,16 @@ export const FetchDatasetVariablesArgsSchema = {
   properties: {
     dataset: {
       type: "string",
-      description: "The dataset identifier (e.g., 'acs/acs1')",
+      description: "The dataset identifier (e.g. 'acs/acs1')",
+    },
+    group: {
+      type: "string",
+      description: "Filter variables by a specific group for this dataset, e.g. 'S0101'"
     },
     year: {
       type: "number",
-      description: "The year of the data",
-    }
+      description: "The year or vintage of the data, e.g. 2022",
+    },
   },
   required: ["dataset"]
 };

--- a/tests/tools/fetch-dataset-variables/fetch-dataset-variables.tool.integration.test.ts
+++ b/tests/tools/fetch-dataset-variables/fetch-dataset-variables.tool.integration.test.ts
@@ -19,17 +19,18 @@ describe('FetchDatasetVariablesTool - Integration Tests', () => {
   it('should fetch real ACS metadata', async () => {
     const tool = new FetchDatasetVariablesTool();
     const datasetName = 'acs/acs1';
+    const datasetYear = 2022;
     
     const response = await tool.handler({
       dataset: datasetName,
-      year: 2022
+      year: datasetYear
     });
 
     expect(response.content[0].type).toBe('text');
     const responseText = response.content[0].text;
 
     expect(responseText).toContain('Total Variables: 36635'); 
-    expect(responseText).toContain('Dataset: acs/acs1 (2022)');
+    expect(responseText).toContain(`Dataset: ${datasetName} (${datasetYear})`);
   }, 10000);
 
   it('should handle real API errors gracefully', async () => {
@@ -55,6 +56,27 @@ describe('FetchDatasetVariablesTool - Integration Tests', () => {
   });
 
   // Separate 
+  describe('when a group is specified', () => {
+    it('should fetch the dataset’s group’s variables', async () => {
+      const tool = new FetchDatasetVariablesTool();
+      const datasetName = 'acs/acs1';
+      const groupLabel = 'B17015';
+      const datasetYear = 2022;
+      
+      const response = await tool.handler({
+        dataset: datasetName,
+        group: groupLabel,
+        year: datasetYear
+      });
+
+      expect(response.content[0].type).toBe('text');
+      const responseText = response.content[0].text;
+
+      expect(responseText).toContain(`Group: ${groupLabel}`); 
+      expect(responseText).toContain('Total Variables: 190');
+    }, 10000);
+  });
+
   describe('when a random dataset is fetched', () => {
     let randomDatasets: Array<{ dataset: string; year?: number; title: string }> = [];
 

--- a/tools/fetch-dataset-variables.tool.ts
+++ b/tools/fetch-dataset-variables.tool.ts
@@ -34,10 +34,16 @@ export class FetchDatasetVariablesTool extends BaseTool<FetchDatasetVariablesArg
 	    }
 
 	    const fetch = (await import("node-fetch")).default;
-	    let year = ""; //Start with a blank year
+	    let group = "";// Start with a blank group
+	    let year = ""; // Start with a blank year
+	    let variablesAppendix = ""; // Assign a blank URL appendix
+
+	    if(args.group){ group = `/groups/${args.group}` } // Add the year if it is present in the input args
 	    if(args.year){ year = `${args.year}/` } // Add the year if it is present in the input args
+	    if(!args.group) { variablesAppendix = '/variables' }
+
 	    
-	    const baseUrl = `https://api.census.gov/data/${year}${args.dataset}/variables.json`; // Construct the URL
+	    const baseUrl = `https://api.census.gov/data/${year}${args.dataset}${group}${variablesAppendix}.json`; // Construct the URL
 			const variablesUrl = `${baseUrl}?key=${apiKey}`; // Add the API Key
 
 
@@ -52,9 +58,15 @@ export class FetchDatasetVariablesTool extends BaseTool<FetchDatasetVariablesArg
 		    	
 		    	// Calculate some useful stats for the LLM
 		    	const totalVariables = variableNames.length;
+		    	let groupResponse = "";
+		    	
+		    	if(args.group) {
+		    		groupResponse = `Group: ${args.group}`;
+		    	}
 		    	
 		    	const responseText = [
 		    	  `Dataset: ${args.dataset}${args.year ? ` (${args.year})` : ''}`,
+		    	  `${groupResponse}`,
 		    	  `Total Variables: ${totalVariables}`,
 		    	  ``,
 		    	  `Complete variable list:`,


### PR DESCRIPTION
Adds support for a group to be specified as an argument to the fetch-dataset-variables tool. This enables the list of variables to be filtered by their group for a given dataset.

* Add group argument acceptance to dataset variables schema
* Add API URL construction logic that supports fetching the variables belonging to a given group for a given dataset
* Update unit and integration tests to include group argument testing
* Update README with group documentation