### PR TITLE
Add A Postgres Container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,43 @@
-version: '3.8'
-
 services:
+  census-mcp-db:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: mcp_db
+      POSTGRES_USER: mcp_user
+      POSTGRES_PASSWORD: mcp_pass
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U mcp_user -d mcp_db"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
   mcp-server:
     build:
       context: ./mcp-server
       dockerfile: Dockerfile
     container_name: mcp-server
     environment:
+      POSTGRES_HOST: postgres
+      POSTGRES_PORT: 5432
+      POSTGRES_DB: census-mcp-db
+      POSTGRES_USER: mcp_user
+      POSTGRES_PASSWORD: mcp_pass
       NODE_ENV: production
+    depends_on:
+      census-mcp-db:
+        condition: service_healthy
     volumes:
       - ./shared:/app/shared:ro
     stdin_open: true
     tty: true
     restart: unless-stopped
+
+volumes:
+  postgres_data:
 
 networks:
   default:


### PR DESCRIPTION
Adds a Postgres Container, the census-mcp-db, to prepare for seeding relevant data to navigating Census data.

* Update Docker Compose to include a new Postgres service, census-mcp-db