### PR TITLE
Updated dataset validator

### DIFF
--- a/mcp-server/src/schema/validators.ts
+++ b/mcp-server/src/schema/validators.ts
@@ -4,7 +4,7 @@ import type { RefinementCtx } from "zod";
 type Dataset = {
 	tool: string;
 	message: string;
-	identifier?: string;
+	identifiers?: string[];
 }
 
 type TableArgs = {
@@ -17,32 +17,30 @@ type TableArgs = {
 const datasets: Dataset[] = [
 	 {
 		tool: "fetch-summary-table",
-		message: "Incompatible dataset. Please use the fetch-summary-table tool."
+		message: "Incompatible dataset. Please use the fetch-summary-table tool.",
 	 },
 	 {
 		tool: "fetch-timeseries-data",
-		message: "Incompatible dataset.",
-		identifier: "timeseries"
+		message: "Incompatible dataset. Please use the (not yet defined) fetch-timeseries-data tool.",
+		identifiers: [ "timeseries" ]
 	 },
 	 {
-		tool: "fetch-pums-microdata",
-		message: "Incompatible dataset.",
-		identifier: "pums"
-	 },
-	 {
-		tool: "fetch-subject-table",
-		message: "Incompatible dataset.",
-		identifier: "subject"
+		tool: "fetch-microdata",
+		message: "Incompatible dataset. Please use the (not yet defined) fetch-microdata tool.",
+		identifiers: [ "cfspum", "cps", "pums", "pumpr", "sipp" ]
 	 }
 ];
 
-export function datasetValidator(url: string): Dataset {
 
-	const matched = datasets.find((dataset: Dataset) =>
-		dataset.identifier ? url.includes(dataset.identifier) : false
+export function datasetValidator(datasetArg: string): Dataset {
+
+	const matched = datasets.find((dataset: Dataset) =>	
+		dataset.identifiers?.some((identifier: string) => 
+			datasetArg.includes(identifier)
+		)
 	);
 
-	return matched ?? datasets.find((dataset: Dataset) => !("identifier" in dataset))!;
+	return matched ?? datasets.find((dataset: Dataset) => !("identifiers" in dataset))!;
 }
 
 export function validateGeographyArgs(args: TableArgs, ctx: RefinementCtx) {

--- a/mcp-server/tests/schema/validators.test.ts
+++ b/mcp-server/tests/schema/validators.test.ts
@@ -11,12 +11,12 @@ type TableArgs = {
 
 describe('datasetValidator', () => {
 	it('returns the correct tool name', () => {
-		const datasets = ["acs/acs1", "timeseries/data/example", "acs/acs1/pums", "acs/acs1/subject", "unknown/data"]
+		const datasets = ["acs/acs1", "timeseries/eits", "acs/acs1/pums", "acs/acs1/subject", "unknown/data"]
 
 		expect(datasetValidator(datasets[0]).tool).toBe("fetch-summary-table");
 		expect(datasetValidator(datasets[1]).tool).toBe("fetch-timeseries-data");
-		expect(datasetValidator(datasets[2]).tool).toBe("fetch-pums-microdata");
-		expect(datasetValidator(datasets[3]).tool).toBe("fetch-subject-table");
+		expect(datasetValidator(datasets[2]).tool).toBe("fetch-microdata");
+		expect(datasetValidator(datasets[3]).tool).toBe("fetch-summary-table");
 		expect(datasetValidator(datasets[4]).tool).toBe("fetch-summary-table");
 	});
 });

--- a/mcp-server/tests/tools/fetch-summary-table/fetch-summary-table.test.ts
+++ b/mcp-server/tests/tools/fetch-summary-table/fetch-summary-table.test.ts
@@ -191,7 +191,8 @@ describe('FetchSummaryTableTool', () => {
         year: 2022, // should be number
         get: { 
           group: 'B01001' 
-        }
+        },
+        for: 'state:*'
       }
 
       const result = tool.validateArgs(invalidArgs);


### PR DESCRIPTION
**Purpose**: Changes in this PR reflect that the API has three categories of data (aggregate, microdata, and timeseries).

**Things I did and why I did them**: 
- Removed fetch-subject-table reference (because subject tables are aggregate data)
- Removed fetch-pums-microdata reference (because PUMS are microdata)
- Made identifiers an array of strings
- Added a fetch-microdata reference and added a list of microdata surveys to look for (the list is comprehensive of all microdatasets available on the Census API)

I'm on the fence about including the "(not yet defined)" for the fetch-timeseries-data and fetch-microdata, not sure if it is necessary or not. 

**Reviewer TODO**: double check the code for `datasetValidator`. 