### PR TITLE
Add Migration Tests for Extensions and Functions

### DIFF
--- a/.github/workflows/test-db.yml
+++ b/.github/workflows/test-db.yml
@@ -112,6 +112,7 @@ jobs:
           npm run test -- --reporter=verbose --coverage.enabled true
 
       - name: Report Coverage
+        if: always()
         uses: davelosert/vitest-coverage-report-action@v2
         continue-on-error: true
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,7 @@ jobs:
         run: npm run test -- --reporter=verbose --coverage.enabled true
 
       - name: Report Coverage
+        if: always()
         uses: davelosert/vitest-coverage-report-action@v2
         continue-on-error: true
         with:

--- a/mcp-db/tests/helpers/normalize-sql.ts
+++ b/mcp-db/tests/helpers/normalize-sql.ts
@@ -1,0 +1,7 @@
+// Function for normalizing SQL to test migration expectations
+export const normalizeSQL = (sql: string): string => {
+  return sql
+    .replace(/\s+/g, ' ')           // Replace multiple whitespace with single space
+    .replace(/\s*\n\s*/g, ' ')      // Replace newlines with spaces
+    .trim();                        // Remove leading/trailing whitespace
+};

--- a/mcp-db/tests/migrations/1751916162107_add-extensions.test.ts
+++ b/mcp-db/tests/migrations/1751916162107_add-extensions.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+import { MigrationBuilder } from 'node-pg-migrate';
+import { up, down } from '../../migrations/1751916162107_add-extensions';
+
+describe('Migration 1751916162107 - Add Extensions', () => {
+  let mockPgm: MigrationBuilder;
+  let sqlSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    sqlSpy = vi.fn().mockResolvedValue(undefined);
+    
+    mockPgm = {
+      sql: sqlSpy,
+      createTable: vi.fn(),
+      dropTable: vi.fn(),
+      addColumn: vi.fn()
+    } as any;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  describe('up', () => {
+    it('should create uuid-ossp extension', async () => {
+      await up(mockPgm);
+      
+      expect(sqlSpy).toHaveBeenCalledWith(
+        'CREATE EXTENSION IF NOT EXISTS "uuid-ossp"'
+      );
+    });
+
+    it('should create pg_trgm extension', async () => {
+      await up(mockPgm);
+      
+      expect(sqlSpy).toHaveBeenCalledWith(
+        'CREATE EXTENSION IF NOT EXISTS pg_trgm'
+      );
+    });
+  });
+
+  describe('down', () => {
+    it('should not execute any SQL', async () => {
+      await down();
+      
+      expect(sqlSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/mcp-db/tests/migrations/1752064297557_add-functions.test.ts
+++ b/mcp-db/tests/migrations/1752064297557_add-functions.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+import { MigrationBuilder } from 'node-pg-migrate';
+
+import { normalizeSQL } from '../helpers/normalize-sql';
+import { up, down } from '../../migrations/1752064297557_add-functions';
+
+describe('Migration 1752064297557 - Add Functions', () => {
+  let mockPgm: MigrationBuilder;
+  let sqlSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    sqlSpy = vi.fn().mockResolvedValue(undefined);
+    
+    mockPgm = {
+      sql: sqlSpy,
+      createTable: vi.fn(),
+      dropTable: vi.fn(),
+      addColumn: vi.fn()
+    } as any;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  describe('up', () => {
+  	const expectedUpdateFunction = normalizeSQL(`
+      CREATE OR REPLACE FUNCTION update_updated_at_column()
+      RETURNS TRIGGER AS $$
+      BEGIN
+          NEW.updated_at = NOW();
+          RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql;
+    `);
+
+    const expectedCacheFunction = normalizeSQL(`
+      CREATE OR REPLACE FUNCTION generate_cache_hash(
+          dataset_code TEXT,
+          year INTEGER,
+          variables TEXT[],
+          geography_spec JSONB
+      )
+      RETURNS TEXT AS $$
+      BEGIN
+          RETURN encode(
+              digest(
+                  dataset_code || year::TEXT || array_to_string(variables, ',') || geography_spec::TEXT,
+                  'sha256'
+              ),
+              'hex'
+          );
+      END;
+      $$ LANGUAGE plpgsql IMMUTABLE;
+    `);
+
+    it('should create or replace function update_updated_at_column', async () => {
+      await up(mockPgm);
+      
+      expect(normalizeSQL(sqlSpy.mock.calls[0][0])).toBe(expectedUpdateFunction);
+    });
+
+    it('should create or replace function generate_cache_hash', async () => {
+      await up(mockPgm);
+      
+      expect(normalizeSQL(sqlSpy.mock.calls[1][0])).toBe(expectedCacheFunction);
+    });
+  });
+
+  describe('down', () => {
+  	it('should drop update_updated_at_column function if it exists', async () => {
+  	  await down(mockPgm);
+  	  
+  	  expect(sqlSpy).toHaveBeenCalledWith(
+  	  	'DROP FUNCTION IF EXISTS update_updated_at_column()'
+  		);
+  	});
+
+    it('should drop generate_cache_hash function if it exists', async () => {
+      await down(mockPgm);
+      
+      expect(sqlSpy).toHaveBeenCalledWith(
+      	'DROP FUNCTION IF EXISTS generate_cache_hash(TEXT, INTEGER, TEXT[], JSONB)'
+    	);
+    });
+  });
+});


### PR DESCRIPTION
Creates a baseline for testing migrations using spies and mocks. This enables direct testing of migration files outside of the integration tests with real data in other tests.

* Add tests for extensions migration
* Add tests for functions migration
* Add normalize-sql helper in tests to test SQL statements without whitespace errors