### PR TITLE
Dynamically Seed Data by Vintage

### DIFF
--- a/mcp-db/src/helpers/geography-years.helper.ts
+++ b/mcp-db/src/helpers/geography-years.helper.ts
@@ -1,0 +1,25 @@
+import { Client } from 'pg'
+
+export const createGeographyYear = async (
+  client: Client,
+  geography_id: number,
+  year_id: number,
+): Promise<{ created: boolean }> => {
+  try {
+    const result = await client.query(
+      `
+  		  INSERT INTO geography_years (geography_id, year_id)
+  		  VALUES ($1, $2)
+  		  ON CONFLICT (geography_id, year_id) 
+  		  DO NOTHING
+  		  RETURNING *
+		  `,
+      [geography_id, year_id],
+    )
+
+    return { created: !!result.rowCount }
+  } catch (error) {
+    console.error('Failed to create geography-year relationship:', error)
+    throw error
+  }
+}

--- a/mcp-db/src/schema/seed-config.schema.ts
+++ b/mcp-db/src/schema/seed-config.schema.ts
@@ -1,38 +1,76 @@
 import { Client } from 'pg'
 import { z, ZodSchema } from 'zod'
 
-export const SeedConfigSchema = z
-  .object({
-    file: z.string().optional(), // For local file seeding
-    url: z.string().url().optional(), // For API Import
-    table: z.string().min(1),
-    conflictColumn: z.string().min(1),
-    dataPath: z.string().optional(),
+import { GeographyRecordSchema } from './geography.schema.js'
 
-    // API options
-    queryParams: z.record(z.string(), z.string()).optional(),
-    timeout: z.number().positive().optional(),
+export const BaseSeedConfigSchema = z.object({
+  file: z.string().optional(),
+  table: z.string().min(1),
+  url: z.string().optional(),
+  conflictColumn: z.string().min(1),
+  dataPath: z.string().optional(),
 
-    // Custom logic for pre and post processing data
-    beforeSeed: z.any().optional(),
-    afterSeed: z.any().optional(),
-  })
-  .strict()
-  .refine((data) => data.file || data.url, {
-    message: "Either 'file' or 'url' must be provided",
-    path: ['file'],
-  })
-  .refine((data) => !(data.file && data.url), {
-    message: "Cannot specify both 'file' and 'url'",
-    path: ['url'],
-  })
+  // Custom logic for pre and post processing data
+  beforeSeed: z.any().optional(),
+  afterSeed: z.any().optional(),
+})
+
+// Extend the BaseSeedConfigSchema for Geographies
+export const GeographySeedConfigSchema = BaseSeedConfigSchema.extend({
+  url: z.any(), // Actual validation for function below
+
+  // Custom logic for pre and post processing data
+  beforeSeed: z.any(),
+  afterSeed: z.any(),
+}).strict()
 
 // TypeScript Type extending Zod schema needed due to Zod constraints validating functions
 export type SeedConfig = Omit<
-  z.infer<typeof SeedConfigSchema>,
-  'beforeSeed' | 'afterSeed' | 'queryParams'
+  z.infer<typeof BaseSeedConfigSchema>,
+  'beforeSeed' | 'afterSeed'
 > & {
-  beforeSeed?: (client: Client, rawData: unknown[]) => void
-  afterSeed?: (client: Client) => Promise<void>
-  queryParams?: Record<string, string | number | boolean>
+  beforeSeed?: (client: Client, rawData: unknown[]) => void | Promise<void>
+  afterSeed?: (client: Client) => void | Promise<void>
+}
+
+export type GeographySeedConfig = Omit<
+  z.infer<typeof GeographySeedConfigSchema>,
+  'beforeSeed' | 'afterSeed'
+> & {
+  url: string | ((context: GeographyContext) => string) // Handles Dynamic URL assignment
+  beforeSeed: (
+    client: Client,
+    rawData: unknown[],
+    context: GeographyContext,
+  ) => void | Promise<void>
+  afterSeed: (
+    client: Client,
+    context: GeographyContext,
+    insertedIds: number[],
+  ) => void | Promise<void>
+}
+
+export const GeographyContextSchema = z.object({
+  year: z.number().int().min(1776),
+  year_id: z.number(),
+  parentGeographies: z
+    .record(z.string(), z.array(GeographyRecordSchema))
+    .optional(),
+})
+
+export type GeographyContext = z.infer<typeof GeographyContextSchema>
+
+export function validateSeedConfigConstraints(
+  config: SeedConfig | GeographySeedConfig,
+): void {
+  const hasFile = !!config.file
+  const hasUrl = !!config.url
+
+  if (!hasFile && !hasUrl) {
+    throw new Error("Either 'file' or 'url' must be provided")
+  }
+
+  if (hasFile && hasUrl) {
+    throw new Error("Cannot specify both 'file' and 'url'")
+  }
 }

--- a/mcp-db/tests/helpers/geography-years.helper.test.ts
+++ b/mcp-db/tests/helpers/geography-years.helper.test.ts
@@ -1,0 +1,99 @@
+import { afterAll, beforeAll, beforeEach, describe, it, expect } from 'vitest'
+import { Client } from 'pg'
+
+import { dbConfig } from '../helpers/database-config'
+import { createGeographyYear } from '../../src/helpers/geography-years.helper'
+
+describe('createGeographyYear', () => {
+  let client: Client
+
+  beforeAll(async () => {
+    client = new Client(dbConfig)
+    await client.connect()
+
+    try {
+      await client.query('DROP TABLE IF EXISTS geography_years CASCADE')
+
+      await client.query(`
+        CREATE TABLE geography_years (
+          id SERIAL PRIMARY KEY,
+          geography_id INTEGER NOT NULL,
+          year_id INTEGER NOT NULL,
+          created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+          updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+          UNIQUE(geography_id, year_id)
+        );
+      `)
+    } catch (error) {
+      console.log('Table setup failed:', error)
+      throw error
+    }
+  })
+
+  afterAll(async () => {
+    try {
+      await client.query('DROP TABLE IF EXISTS geography_years CASCADE')
+    } catch (error) {
+      console.log('Cleanup failed:', error)
+    }
+    await client.end()
+  })
+
+  beforeEach(async () => {
+    await client.query(
+      'TRUNCATE TABLE geography_years RESTART IDENTITY CASCADE',
+    )
+  })
+
+  it('creates a geography_years record', async () => {
+    const geographyID = 1
+    const yearID = 2
+
+    const result = await createGeographyYear(client, geographyID, yearID)
+
+    const query = await client.query<{
+      geographyID: number
+      yearID: number
+    }>(
+      `
+      SELECT geography_id, year_id
+      FROM geography_years
+      WHERE geography_id = $1 AND year_id = $2
+    `,
+      [geographyID, yearID],
+    )
+
+    expect(query.rows).toHaveLength(1)
+    expect(query.rows[0].geography_id).toBe(geographyID)
+    expect(query.rows[0].year_id).toBe(yearID)
+    expect(result.created).toBe(true)
+  })
+
+  it('handles duplicate relationships gracefully', async () => {
+    const geographyID = 1
+    const yearID = 2
+
+    const firstResult = await createGeographyYear(client, geographyID, yearID)
+    expect(firstResult.created).toBe(true)
+
+    const secondResult = await createGeographyYear(client, geographyID, yearID)
+    expect(secondResult.created).toBe(false)
+
+    const query = await client.query(
+      `
+      SELECT COUNT(*) as count 
+      FROM geography_years 
+      WHERE geography_id = $1 AND year_id = $2
+    `,
+      [geographyID, yearID],
+    )
+
+    expect(parseInt(query.rows[0].count)).toBe(1)
+  })
+
+  it('handles invalid input gracefully', async () => {
+    await expect(
+      createGeographyYear(client, null as unknown, 1),
+    ).rejects.toThrow()
+  })
+})

--- a/mcp-db/tests/schema/seed-config.schema.test.ts
+++ b/mcp-db/tests/schema/seed-config.schema.test.ts
@@ -1,29 +1,36 @@
 import { describe, expect, it } from 'vitest'
-import { SeedConfigSchema } from '../../src/schema/seed-config.schema'
+import {
+  BaseSeedConfigSchema,
+  GeographyContext,
+  GeographyContextSchema,
+  GeographySeedConfig,
+  GeographySeedConfigSchema,
+  SeedConfig,
+  validateSeedConfigConstraints,
+} from '../../src/schema/seed-config.schema'
 
-describe('SeedConfig', () => {
-  it('should succeed when validated', async () => {
-    const seedConfig = {
-      url: 'https://www.census.gov',
+describe('BaseSeedConfigSchema', () => {
+  it('should succeed when validated with base schema', async () => {
+    const config = {
       table: 'summary_levels',
       dataPath: 'summary_levels',
       conflictColumn: 'id',
     }
 
-    const result = SeedConfigSchema.safeParse(seedConfig)
+    const result = BaseSeedConfigSchema.safeParse(config)
 
     expect(result.success).toBe(true)
   })
 
   it('should throw error when conflictColumn is missing', async () => {
-    const seedConfig = {
-      file: 'summary_levels_no_conflict.json',
+    const config = {
+      file: 'test.json',
       table: 'summary_levels',
       dataPath: 'summary_levels',
       // conflictColumn is missing
     }
 
-    const result = SeedConfigSchema.safeParse(seedConfig)
+    const result = BaseSeedConfigSchema.safeParse(config)
 
     expect(result.success).toBe(false)
 
@@ -32,16 +39,172 @@ describe('SeedConfig', () => {
         issue.path.includes('conflictColumn'),
       )
 
-      console.log(conflictColumnError)
-
-      expect(conflictColumnError).toEqual(
-        expect.objectContaining({
-          code: 'invalid_type',
-          path: ['conflictColumn'],
-          message: 'Invalid input: expected string, received undefined',
-          expected: 'string',
-        }),
-      )
+      expect(conflictColumnError).toBeDefined()
+      expect(conflictColumnError?.code).toBe('invalid_type')
+      expect(conflictColumnError?.path).toEqual(['conflictColumn'])
+      expect(conflictColumnError?.expected).toBe('string')
+      // Remove the exact message check as it may vary between Zod versions
     }
+  })
+})
+
+describe('SeedConfig', () => {
+  it('should reject config with both file and url', () => {
+    const config: SeedConfig = {
+      file: 'test.json',
+      url: 'https://api.example.com/data',
+      table: 'test_table',
+      conflictColumn: 'id',
+    }
+
+    expect(() => validateSeedConfigConstraints(config)).toThrow(
+      "Cannot specify both 'file' and 'url'",
+    )
+  })
+
+  it('should reject config with neither file nor url', () => {
+    const config: SeedConfig = {
+      table: 'test_table',
+      conflictColumn: 'id',
+      // No file or url
+    }
+
+    expect(() => validateSeedConfigConstraints(config)).toThrow(
+      "Either 'file' or 'url' must be provided",
+    )
+  })
+
+  it('should accept config with only file', () => {
+    const config: SeedConfig = {
+      file: 'test.json',
+      table: 'test_table',
+      conflictColumn: 'id',
+    }
+
+    expect(() => validateSeedConfigConstraints(config)).not.toThrow()
+  })
+
+  it('should accept config with only static url string', () => {
+    const config: SeedConfig = {
+      url: 'https://api.example.com/data',
+      table: 'test_table',
+      conflictColumn: 'id',
+    }
+
+    expect(() => validateSeedConfigConstraints(config)).not.toThrow()
+  })
+})
+
+describe('GeographyContextSchema', () => {
+  it('should accept valid geography records', () => {
+    const GeographyContext = {
+      year: 2023,
+      year_id: 1,
+      parentGeographies: {
+        states: [
+          {
+            name: 'Alabama',
+            ucgid_code: '0400000US01',
+            geo_id: '0400000US01',
+            summary_level_code: '040',
+            for_param: 'state:*', // Fixed: should be 'state:*', not 'state:01'
+            in_param: null,
+            year: 2023,
+            intptlat: 32.31823,
+            intptlon: -86.902298,
+          },
+        ],
+      },
+    }
+
+    const result = GeographyContextSchema.safeParse(GeographyContext)
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.parentGeographies?.states?.[0].name).toBe('Alabama')
+    }
+  })
+
+  it('should return false on empty definitions', () => {
+    const GeographyContext = {}
+
+    const result = GeographyContextSchema.safeParse(GeographyContext)
+
+    expect(result.success).toBe(false)
+  })
+
+  it('should reject invalid geography records', () => {
+    const GeographyContext = {
+      parentGeographies: {
+        states: [
+          {
+            name: 'Alabama',
+            // Missing required fields
+          },
+        ],
+      },
+    }
+
+    const result = GeographyContextSchema.safeParse(GeographyContext)
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues.length).toBeGreaterThan(0)
+      // Check that some required field is missing
+      expect(
+        result.error.issues.some((issue) => issue.code === 'invalid_type'),
+      ).toBe(true)
+    }
+  })
+
+  it('should validate year constraints', () => {
+    const GeographyContext = {
+      year: 1775, // Before 1776 Fails. 'merica 🇺🇸
+      year_id: 1,
+    }
+
+    const result = GeographyContextSchema.safeParse(GeographyContext)
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(
+        result.error.issues.some(
+          (issue) => issue.path.includes('year') && issue.code === 'too_small',
+        ),
+      ).toBe(true)
+    }
+  })
+
+  it('should be successful with required arguments', () => {
+    const GeographyContext = {
+      year: 2023,
+      year_id: 1,
+    }
+
+    const result = GeographyContextSchema.safeParse(GeographyContext)
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.year).toBe(2023)
+      expect(result.data.parentGeographies).toBeUndefined()
+    }
+  })
+})
+
+describe('GeographySeedConfig', () => {
+  it('should be successful with required arguments', () => {
+    const config: GeographySeedConfig = {
+      url: (context: GeographyContext) =>
+        `https://www.census.gov/data/${context.year}`,
+      table: 'summary_levels',
+      dataPath: 'summary_levels',
+      conflictColumn: 'id',
+    }
+
+    const zodResult = GeographySeedConfigSchema.safeParse(config)
+    expect(zodResult.success).toBe(true)
+
+    // Then validate the constraints
+    expect(() => validateSeedConfigConstraints(config)).not.toThrow()
   })
 })

--- a/mcp-db/tests/seeds/seed.integration.test.ts
+++ b/mcp-db/tests/seeds/seed.integration.test.ts
@@ -23,11 +23,6 @@ interface MockServer {
   close(): CloseAction
 }
 
-interface QueryParams {
-  format: string
-  limit: string
-}
-
 describe('Seed Database - API Integration Tests', () => {
   let runner: SeedRunner
   let client: Client
@@ -147,40 +142,5 @@ describe('Seed Database - API Integration Tests', () => {
     // Verify no data was inserted due to rollback
     const result = await client.query('SELECT COUNT(*) FROM api_test_data')
     expect(result.rows[0].count).toBe('0')
-  })
-
-  it('should handle query parameters correctly', async () => {
-    // Verify query params are sent to API
-    let receivedParams: QueryParams = {}
-
-    mockServer.get('/test-with-params', (req, res) => {
-      receivedParams = req.query
-      res.json({ data: [{ id: 1, name: 'Test', value: 42 }] })
-    })
-
-    const seedConfig = {
-      url: `http://localhost:${mockServer.port}/test-with-params`,
-      table: 'api_test_data',
-      conflictColumn: 'id',
-      dataPath: 'data',
-      queryParams: {
-        api_key: 'test123',
-        format: 'json',
-        year: '2024',
-      },
-    }
-
-    await runner.seed(seedConfig)
-
-    // Verify query params were sent correctly
-    expect(receivedParams).toMatchObject({
-      api_key: 'test123',
-      format: 'json',
-      year: '2024',
-    })
-
-    // Verify data was inserted
-    const result = await client.query('SELECT * FROM api_test_data')
-    expect(result.rows).toHaveLength(1)
   })
 })


### PR DESCRIPTION
Adds support for seeding data by vintage (years). This includes updated the seed-runner and seed-database to include new functions and support for passing vintage data to configs, new helper methods for creating relationships between years and geographies, and reducing the database operations in the afterseed function for the nation config.

* Add getAvailableYears function to SeedRunner to access available Years
* Update insertOrSkip and insertOrSkip batch functions in SeedRunner to return an array of inserted record IDs
* Update SeedConfigSchema and SeedContextSchema to support passing year and year_id to configs
* Update NationConfig afterSeed function to loop through inserted geographies and call the junction table helper to create relationships
* Add createGeographyYears helper to create geography years relationships
* Update seed function in SeedRunner to pass insertedIDs to Config