### PR TITLE
Add Support for Production Rebuilds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,8 +93,11 @@ jobs:
         uses: docker/setup-buildx-action@v3
     
       - name: Build production Docker images
-        run: |
-          docker compose --profile prod build --no-cache
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 3
+          command: docker compose --profile prod build --no-cache
     
       - name: Test production environment
         run: |
@@ -149,7 +152,6 @@ jobs:
           echo "=== MCP Server Status ==="
           docker compose --profile prod logs mcp-server | head -20
  
-    
       - name: Cleanup production environment
         if: always()
         run: |

--- a/.github/workflows/test-db.yml
+++ b/.github/workflows/test-db.yml
@@ -80,6 +80,10 @@ jobs:
             sleep 2
           done
 
+      - name: Build the environment
+        working-directory: ./mcp-db
+        run: npm run build
+
       - name: Run database migrations
         working-directory: ./mcp-db
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,10 @@ jobs:
       - name: Install database dependencies
         working-directory: ./mcp-db
         run: npm ci
+
+      - name: Build the environment
+        working-directory: ./mcp-db
+        run: npm run build
         
       - name: Run database migrations
         working-directory: ./mcp-db

--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ Note that the `CENSUS_API_KEY` variable is required. This defines the `env` vari
 
 Be sure to update the path to the `mcp-server-census-api` directory in `args` and provide a valid `CENSUS_API_KEY`.
 
+### Updating the MCP Server
+When a new version of this project is released, you will need to manually build the production environment for the latest features. From the `mcp-db/` directory, run the following:
+
+```
+npm run prod:down
+npm run prod:build
+```
+
+After that, you can relaunch your MCP Client and it should connect to the server again.
+
 ## How the MCP Server Works
 
 The U.S. Census Bureau MCP Server uses data from the Census Data API and other official sources to construct contextually rich data and statistics for use with AI Assistants. The Census Data API is the primary source of data but some of the API's data is pulled down to a local postgres container to enable more robust and performant search functionality. Below is an illustration of how user prompts are processed by AI Assistants and the MCP Server.

--- a/mcp-db/Dockerfile
+++ b/mcp-db/Dockerfile
@@ -1,9 +1,9 @@
-#Dev Environment
 FROM node:20-alpine AS dev
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci --silent
 COPY . .
+RUN ls -la data/ || echo "No data directory found in source"
 RUN npm run build
 CMD ["sh", "-c", "npm run migrate:up"]
 
@@ -12,5 +12,6 @@ FROM node:20-slim AS prod
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci --omit=dev --silent
-COPY . .
-CMD ["sh", "-c", "npm run migrate:up && npm run seed"]
+COPY --from=dev /app/dist ./dist
+COPY --from=dev /app/data ./data
+CMD ["sh", "-c", "npm run migrate:up && npm run seed:prod"]

--- a/mcp-db/package-lock.json
+++ b/mcp-db/package-lock.json
@@ -11,7 +11,6 @@
         "dotenv": "^17.1.0",
         "node-pg-migrate": "^8.0.3",
         "pg": "^8.11.3",
-        "typescript": "^5.8.3",
         "zod": "^4.0.5"
       },
       "devDependencies": {
@@ -24,7 +23,8 @@
         "globals": "^16.2.0",
         "prettier": "^3.6.2",
         "shx": "^0.4.0",
-        "tsx": "^4.20.3",
+        "tsx": "^4.20.4",
+        "typescript": "^5.8.3",
         "typescript-eslint": "^8.33.1",
         "vitest": "^3.2.4"
       }
@@ -4951,9 +4951,9 @@
       }
     },
     "node_modules/tsx": {
-      "version": "4.20.3",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.3.tgz",
-      "integrity": "sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==",
+      "version": "4.20.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.4.tgz",
+      "integrity": "sha512-yyxBKfORQ7LuRt/BQKBXrpcq59ZvSW0XxwfjAt3w2/8PmdxaFzijtMhTawprSHhpzeM5BgU2hXHG3lklIERZXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5002,6 +5002,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/mcp-db/package.json
+++ b/mcp-db/package.json
@@ -3,15 +3,18 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "build": "tsc && shx chmod +x dist/*.js || true",
+    "build": "tsc && tsc -p tsconfig.migrations.json && shx chmod +x dist/*.js || true",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "lint": "eslint migrations/ tests/",
     "migrate:create": "npx tsx node_modules/.bin/node-pg-migrate create --migration-file-language ts",
-    "migrate:down": "npx tsx node_modules/.bin/node-pg-migrate down --verbose",
-    "migrate:up": "npx tsx node_modules/.bin/node-pg-migrate up --verbose",
+    "migrate:down": "node-pg-migrate down --verbose --migrations-dir dist/migrations",
+    "migrate:up": "node-pg-migrate up --verbose --migrations-dir dist/migrations",
+    "prod:build": "docker compose --profile prod up --build -d",
+    "prod:down": "docker compose --profile prod down",
     "schema:dump": "docker compose --profile dev exec census-mcp-db-dev pg_dump --schema-only --no-owner --no-privileges --username=mcp_user_dev mcp_db_dev > schema.sql",
     "seed": "npm run build && node dist/seeds/scripts/seed-database.js",
+    "seed:prod": "node dist/seeds/scripts/seed-database.js",
     "test": "vitest --printConsoleTrace=true --silent=false",
     "test:coverage": "vitest --coverage"
   },
@@ -19,7 +22,6 @@
     "dotenv": "^17.1.0",
     "node-pg-migrate": "^8.0.3",
     "pg": "^8.11.3",
-    "typescript": "^5.8.3",
     "zod": "^4.0.5"
   },
   "devDependencies": {
@@ -32,7 +34,8 @@
     "globals": "^16.2.0",
     "prettier": "^3.6.2",
     "shx": "^0.4.0",
-    "tsx": "^4.20.3",
+    "tsx": "^4.20.4",
+    "typescript": "^5.8.3",
     "typescript-eslint": "^8.33.1",
     "vitest": "^3.2.4"
   }

--- a/mcp-db/tsconfig.migrations.json
+++ b/mcp-db/tsconfig.migrations.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "outDir": "./dist/migrations",
+    "rootDir": "./migrations",
+    "strict": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["migrations/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Modifies the mcp-db Dockerfile to build the project before deployment.

* Adds build support in the Dockerfile for the prod environment
* Add prod:down and prod:build scripts in mcp-db to support rebuilding the Docker prod environment
* Update the README with instructions for rebuilding the Docker prod environment