### PR TITLE
Added US to `for` and `ucgid` parameter examples in table-schema.ts

### DIFF
--- a/mcp-server/src/schema/table.schema.ts
+++ b/mcp-server/src/schema/table.schema.ts
@@ -54,6 +54,7 @@ export const geoProperties = {
     description:
       "Geography restriction as comma-separated values. Required if 'ucgid' not defined.",
     examples: [
+      'us:*',
       'state:*',
       'state:01,02,06',
       'county:001',
@@ -77,7 +78,7 @@ export const geoProperties = {
     type: 'string',
     description:
       "Alternative geography specification using Uniform Census Geography Identifier (UCGID). Required if 'for' not defined.",
-    examples: ['0400000US06', '0400000US41'],
+    examples: ['0100000US', '0400000US06', '0400000US41'],
   },
 }
 


### PR DESCRIPTION
**Purpose**: Added US to `for` and `ucgid` parameter examples in table-schema.ts

**Why**: These examples seem to get used when the model doesn't receive or can't determine what parameters to use based on the user's intent (i.e. if a user doesn't specify a geography, the model has defaulted to using `&for=state:*`). With this change, it should default to using `&for=us:*`. The nation is a more sensible default and also what's used by DCG. 