### PR TITLE
Create GeographyResolutionFips Tool

### DIFF
--- a/mcp-db/migrations/1756926825327_add-geographies-search-functions.ts
+++ b/mcp-db/migrations/1756926825327_add-geographies-search-functions.ts
@@ -1,0 +1,214 @@
+import { MigrationBuilder } from 'node-pg-migrate'
+
+export const summaryLevelsNameIdxSql = `
+	CREATE INDEX IF NOT EXISTS idx_summary_levels_name_gin 
+	ON summary_levels 
+	USING gin (name gin_trgm_ops);
+`
+
+export const summaryLevelsCodeIdxSql = `
+	CREATE INDEX IF NOT EXISTS idx_summary_levels_code 
+	ON summary_levels (code);
+`
+
+export const dropFunctionSql = `
+	DROP FUNCTION IF EXISTS search_places(text, character, text[], integer);
+  DROP FUNCTION IF EXISTS fuzzy_search_places CASCADE;
+  DROP FUNCTION IF EXISTS resolve_geography_by_coordinates CASCADE;
+`
+
+export const hierarchySql = `
+  UPDATE summary_levels SET hierarchy_level = 
+    CASE code
+      WHEN '010' THEN 1   -- Nation
+      WHEN '040' THEN 2   -- State
+      WHEN '160' THEN 3   -- Place (Incorporated Place)
+      WHEN '050' THEN 4   -- County
+      WHEN '060' THEN 5   -- County Subdivision
+      WHEN '020' THEN 6   -- Region (lower priority than counties)
+      WHEN '030' THEN 7   -- Division (lower priority than counties)
+      WHEN '140' THEN 8   -- Census Tract
+      WHEN '150' THEN 9   -- Block Group
+      WHEN '860' THEN 10  -- ZIP Code Tabulation Area
+      ELSE 99             -- All others get lowest priority
+    END;
+`
+
+export const searchGeographiesSql = `
+  SELECT 
+    g.id,
+    g.name,
+    sl.name as summary_level_name,
+    g.latitude,
+    g.longitude,
+    g.for_param,
+    g.in_param,
+    -- Weighted score: similarity + hierarchy boost
+    (SIMILARITY(g.name, search_term) + (1.0 - (sl.hierarchy_level::real / 100.0))) as weighted_score
+  FROM geographies g
+  LEFT JOIN summary_levels sl ON g.summary_level_code = sl.code
+  WHERE 
+    g.name % search_term  -- Uses trigram similarity operator
+    OR g.name ILIKE '%' || search_term || '%'  -- Fallback for partial matches
+  ORDER BY 
+    weighted_score DESC,  -- Combined similarity + hierarchy score
+    LENGTH(g.name) ASC,   -- Prefer shorter names when scores are equal
+    g.name ASC
+  LIMIT result_limit;
+`
+
+export const searchGeographiesBySummaryLevelSql = `
+	SELECT 
+	  g.id,
+	  g.name,
+	  sl.name as summary_level_name,
+	  g.latitude,
+	  g.longitude,
+	  g.for_param,
+	  g.in_param,
+	  SIMILARITY(g.name, search_term) as similarity
+	FROM geographies g
+	LEFT JOIN summary_levels sl ON g.summary_level_code = sl.code
+	WHERE 
+	  g.summary_level_code = summary_level_code
+	  AND (
+	    g.name % search_term  -- Uses trigram similarity operator
+	    OR g.name ILIKE '%' || search_term || '%'  -- Fallback for partial matches
+	  )
+	ORDER BY 
+	  SIMILARITY(g.name, search_term) DESC,
+	  LENGTH(g.name) ASC,   -- Prefer shorter names when similarity is equal
+	  g.name ASC
+	LIMIT result_limit;
+`
+
+export const searchGeographiesReturnSql = `
+	TABLE(
+		id INTEGER, 
+		name TEXT, 
+		summary_level_name TEXT, 
+		latitude NUMERIC, 
+		longitude NUMERIC, 
+		for_param TEXT, 
+		in_param TEXT, 
+		weighted_score REAL
+	)
+`
+
+export const searchGeographiesBySummaryLevelReturnSql = `
+	TABLE(
+		id INTEGER, 
+		name TEXT, 
+		summary_level_name TEXT, 
+		latitude NUMERIC, 
+		longitude NUMERIC, 
+		for_param TEXT, 
+		in_param TEXT, 
+		similarity REAL
+	)
+`
+
+export const searchSummaryLevelsSql = `
+  SELECT 
+    sl.code as code,
+    sl.name as name
+  FROM summary_levels sl
+  WHERE 
+    sl.code = LPAD($1, 3, '0')  -- exact code match
+    OR LOWER(sl.name) = LOWER(TRIM($1))  -- exact name match
+    OR SIMILARITY(LOWER(sl.name), LOWER(TRIM($1))) > 0.3  -- fuzzy name match
+  ORDER BY 
+    CASE 
+      WHEN sl.code = LPAD($1, 3, '0') THEN 1.00
+      WHEN LOWER(sl.name) = LOWER(TRIM($1)) THEN 1.00
+      ELSE SIMILARITY(LOWER(sl.name), LOWER(TRIM($1)))
+    END DESC,
+    CASE 
+      WHEN sl.code = LPAD($1, 3, '0') THEN 1
+      WHEN LOWER(sl.name) = LOWER(TRIM($1)) THEN 2
+      ELSE 3
+    END
+  LIMIT COALESCE($2, 5)
+`
+
+export const searchSummaryLevelsReturnSql = `
+  TABLE (
+    code TEXT,
+    name TEXT
+  )
+`
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  // Drop search functions referencing older tables
+  pgm.sql(dropFunctionSql)
+
+  pgm.addColumns('summary_levels', {
+    hierarchy_level: { type: 'integer', default: 99 },
+  })
+
+  // Update hierarchy levels in summary_levels based on summary level popularity
+  pgm.sql(hierarchySql)
+
+  // Create the search function with weighted summary level priority
+  pgm.createFunction(
+    'search_geographies',
+    [
+      { name: 'search_term', type: 'TEXT' },
+      { name: 'result_limit', type: 'INTEGER', default: 10 },
+    ],
+    {
+      returns: searchGeographiesReturnSql,
+      language: 'sql',
+      stable: true,
+    },
+    searchGeographiesSql,
+  )
+
+  // Create a filtered search function by summary level
+  pgm.createFunction(
+    'search_geographies_by_summary_level',
+    [
+      { name: 'search_term', type: 'TEXT' },
+      { name: 'summary_level_code', type: 'TEXT' },
+      { name: 'result_limit', type: 'INTEGER', default: 10 },
+    ],
+    {
+      returns: searchGeographiesBySummaryLevelReturnSql,
+      language: 'sql',
+      stable: true,
+    },
+    searchGeographiesBySummaryLevelSql,
+  )
+
+  pgm.createFunction(
+    'search_summary_levels',
+    [
+      { name: 'search_term', type: 'TEXT' },
+      { name: 'result_limit', type: 'INTEGER', default: 1 },
+    ],
+    {
+      returns: searchSummaryLevelsReturnSql,
+      language: 'sql',
+      stable: true,
+    },
+    searchSummaryLevelsSql,
+  )
+
+  pgm.sql(summaryLevelsNameIdxSql)
+  pgm.sql(summaryLevelsCodeIdxSql)
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  pgm.dropFunction('search_geographies_by_summary_level', [
+    'TEXT',
+    'TEXT',
+    'INTEGER',
+  ])
+  pgm.dropFunction('search_geographies', ['TEXT', 'INTEGER'])
+  pgm.dropFunction('search_summary_levels', ['TEXT', 'INTEGER'])
+
+  pgm.dropColumns('summary_levels', ['hierarchy_level'])
+
+  pgm.sql('DROP INDEX IF EXISTS idx_summary_levels_name_gin;')
+  pgm.sql('DROP INDEX IF EXISTS idx_summary_levels_code;')
+}

--- a/mcp-db/tests/migrations/1756926825327_add-geographies-search-functions.test.ts
+++ b/mcp-db/tests/migrations/1756926825327_add-geographies-search-functions.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest'
+import { MigrationBuilder } from 'node-pg-migrate'
+
+import { normalizeSQL } from '../helpers/normalize-sql'
+import {
+  down,
+  dropFunctionSql,
+  hierarchySql,
+  searchGeographiesBySummaryLevelSql,
+  searchGeographiesBySummaryLevelReturnSql,
+  searchGeographiesSql,
+  searchGeographiesReturnSql,
+  summaryLevelsNameIdxSql,
+  summaryLevelsCodeIdxSql,
+  up,
+} from '../../migrations/1756926825327_add-geographies-search-functions'
+
+describe('Migration 1756926825327 - Add Geographies Search Functions', () => {
+  let mockPgm: MigrationBuilder
+  let sqlSpy: ReturnType<typeof vi.fn>
+  let addColumnsSpy: ReturnType<typeof vi.fn>
+  let dropColumnsSpy: ReturnType<typeof vi.fn>
+  let addIndexSpy: ReturnType<typeof vi.fn>
+  let dropIndexSpy: ReturnType<typeof vi.fn>
+  let createFunctionSpy: ReturnType<typeof vi.fn>
+  let dropFunctionSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    sqlSpy = vi.fn().mockResolvedValue(undefined)
+    addColumnsSpy = vi.fn().mockResolvedValue(undefined)
+    dropColumnsSpy = vi.fn().mockResolvedValue(undefined)
+    addIndexSpy = vi.fn().mockResolvedValue(undefined)
+    dropIndexSpy = vi.fn().mockResolvedValue(undefined)
+    createFunctionSpy = vi.fn().mockResolvedValue(undefined)
+    dropFunctionSpy = vi.fn().mockResolvedValue(undefined)
+
+    mockPgm = {
+      sql: sqlSpy,
+      addColumns: addColumnsSpy,
+      dropColumns: dropColumnsSpy,
+      addIndex: addIndexSpy,
+      dropIndex: dropIndexSpy,
+      createFunction: createFunctionSpy,
+      dropFunction: dropFunctionSpy,
+    } as MigrationBuilder
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+  })
+
+  describe('up', () => {
+    beforeEach(async () => {
+      await up(mockPgm)
+    })
+
+    it('removes the old search functions if they exist', () => {
+      expect(normalizeSQL(sqlSpy.mock.calls[0][0])).toBe(
+        normalizeSQL(dropFunctionSql),
+      )
+    })
+
+    it('adds hierarchy_level column to summary_levels', () => {
+      expect(addColumnsSpy).toHaveBeenCalledWith('summary_levels', {
+        hierarchy_level: { type: 'integer', default: 99 },
+      })
+    })
+
+    it('seeds hierarchy_level data in summary_levels', () => {
+      expect(normalizeSQL(sqlSpy.mock.calls[1][0])).toBe(
+        normalizeSQL(hierarchySql),
+      )
+    })
+
+    it('creates the geography search functions', () => {
+      expect(createFunctionSpy).toHaveBeenCalledWith(
+        'search_geographies',
+        [
+          { name: 'search_term', type: 'TEXT' },
+          { name: 'result_limit', type: 'INTEGER', default: 10 },
+        ],
+        {
+          returns: searchGeographiesReturnSql,
+          language: 'sql',
+          stable: true,
+        },
+        searchGeographiesSql,
+      )
+
+      expect(createFunctionSpy).toHaveBeenCalledWith(
+        'search_geographies_by_summary_level',
+        [
+          { name: 'search_term', type: 'TEXT' },
+          { name: 'summary_level_code', type: 'TEXT' },
+          { name: 'result_limit', type: 'INTEGER', default: 10 },
+        ],
+        {
+          returns: searchGeographiesBySummaryLevelReturnSql,
+          language: 'sql',
+          stable: true,
+        },
+        searchGeographiesBySummaryLevelSql,
+      )
+    })
+
+    it('creates indexes on summary_levels table', async () => {
+      expect(normalizeSQL(sqlSpy.mock.calls[2][0])).toBe(
+        normalizeSQL(summaryLevelsNameIdxSql),
+      )
+      expect(normalizeSQL(sqlSpy.mock.calls[3][0])).toBe(
+        normalizeSQL(summaryLevelsCodeIdxSql),
+      )
+    })
+  })
+
+  describe('down', () => {
+    beforeEach(async () => {
+      await down(mockPgm)
+    })
+
+    it('drops the new search functions', async () => {
+      expect(dropFunctionSpy).toHaveBeenCalledWith(
+        'search_geographies_by_summary_level',
+        ['TEXT', 'TEXT', 'INTEGER'],
+      )
+
+      expect(dropFunctionSpy).toHaveBeenCalledWith('search_geographies', [
+        'TEXT',
+        'INTEGER',
+      ])
+
+      expect(dropFunctionSpy).toHaveBeenCalledWith('search_summary_levels', [
+        'TEXT',
+        'INTEGER',
+      ])
+    })
+
+    it('drops the hiearchy_level column on summary_levels', async () => {
+      expect(dropColumnsSpy).toHaveBeenCalledWith('summary_levels', [
+        'hierarchy_level',
+      ])
+    })
+
+    it('drops the indexes summary_levels', () => {
+      expect(sqlSpy).toHaveBeenCalledWith(
+        'DROP INDEX IF EXISTS idx_summary_levels_name_gin;',
+      )
+      expect(sqlSpy).toHaveBeenCalledWith(
+        'DROP INDEX IF EXISTS idx_summary_levels_code;',
+      )
+    })
+  })
+})

--- a/mcp-db/tests/schema/schema.test.ts
+++ b/mcp-db/tests/schema/schema.test.ts
@@ -96,31 +96,5 @@ describe('Database Schema', () => {
 
       expect(result.rows[0].exists).toBe(true)
     })
-
-    it('should have search_places function', async () => {
-      const result: QueryResult<{ exists: boolean }> = await client.query(`
-        SELECT EXISTS (
-          SELECT FROM information_schema.routines 
-          WHERE routine_schema = 'public' 
-          AND routine_name = 'search_places'
-          AND routine_type = 'FUNCTION'
-        );
-      `)
-
-      expect(result.rows[0].exists).toBe(true)
-    })
-
-    it('should have fuzzy_search_places function', async () => {
-      const result: QueryResult<{ exists: boolean }> = await client.query(`
-        SELECT EXISTS (
-          SELECT FROM information_schema.routines 
-          WHERE routine_schema = 'public' 
-          AND routine_name = 'fuzzy_search_places'
-          AND routine_type = 'FUNCTION'
-        );
-      `)
-
-      expect(result.rows[0].exists).toBe(true)
-    })
   })
 })

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -13,6 +13,7 @@ import { FetchDatasetGeographyTool } from './tools/fetch-dataset-geography.tool.
 import { FetchDatasetVariablesTool } from './tools/fetch-dataset-variables.tool.js'
 import { FetchSummaryTableTool } from './tools/fetch-summary-table.tool.js'
 import { IdentifyDatasetsTool } from './tools/identify-datasets.tool.js'
+import { ResolveGeographyFipsTool } from './tools/resolve-geography-fips.tool.js'
 
 // MCP Server Setup
 async function main() {
@@ -23,6 +24,7 @@ async function main() {
   mcpServer.registerTool(new FetchDatasetVariablesTool())
   mcpServer.registerTool(new FetchSummaryTableTool())
   mcpServer.registerTool(new IdentifyDatasetsTool())
+  mcpServer.registerTool(new ResolveGeographyFipsTool())
 
   const transport = new StdioServerTransport()
   await mcpServer.connect(transport)

--- a/mcp-server/src/schema/identify-datasets.schema.ts
+++ b/mcp-server/src/schema/identify-datasets.schema.ts
@@ -11,7 +11,6 @@ export const SimplifiedAPIDatasetSchema = z.object({
   c_isMicrodata: z.boolean().optional(),
 })
 
-
 export const DatasetSchema = z.object({
   c_vintage: z.number().optional(),
   c_dataset: z.array(z.string()),
@@ -32,14 +31,16 @@ export const DatasetSchema = z.object({
   accessLevel: z.string(),
   bureauCode: z.array(z.string()),
   description: z.string(),
-  distribution: z.array(z.object({
-    "@type": z.string(),
-    accessURL: z.string(),
-    description: z.string(),
-    format: z.string(),
-    mediaType: z.string(),
-    title: z.string(),
-  })),
+  distribution: z.array(
+    z.object({
+      '@type': z.string(),
+      accessURL: z.string(),
+      description: z.string(),
+      format: z.string(),
+      mediaType: z.string(),
+      title: z.string(),
+    }),
+  ),
   contactPoint: z.object({
     fn: z.string(),
     hasEmail: z.string(),
@@ -55,10 +56,12 @@ export const DatasetSchema = z.object({
   publisher: z.object({
     '@type': z.string(),
     name: z.string(),
-    subOrganizationOf: z.object({
-      '@type': z.string(),
-      name: z.string(),
-    }).optional(),
+    subOrganizationOf: z
+      .object({
+        '@type': z.string(),
+        name: z.string(),
+      })
+      .optional(),
   }),
 })
 
@@ -69,11 +72,14 @@ export const AllDatasetMetadataJsonSchema = z.object({
   '@type': z.string(),
   conformsTo: z.string(),
   describedBy: z.string(),
-  dataset: z.array(DatasetSchema)
+  dataset: z.array(DatasetSchema),
 })
 
-
 // Infer TypeScript types from Zod schemas
-export type SimplifiedAPIDatasetType = z.infer<typeof SimplifiedAPIDatasetSchema>;
-export type AllDatasetMetadataJsonResponseType = z.infer<typeof AllDatasetMetadataJsonSchema>;
+export type SimplifiedAPIDatasetType = z.infer<
+  typeof SimplifiedAPIDatasetSchema
+>
+export type AllDatasetMetadataJsonResponseType = z.infer<
+  typeof AllDatasetMetadataJsonSchema
+>
 export type DatasetType = z.infer<typeof DatasetSchema>

--- a/mcp-server/src/schema/resolve-geography-fips.schema.ts
+++ b/mcp-server/src/schema/resolve-geography-fips.schema.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod'
+
+export const ResolveGeographyFipsInputSchema = z.object({
+  geography_name: z.string().describe('The name of the Geography to resolve.'),
+  summary_level: z
+    .string()
+    .describe('The name or code of the Summary Level to search.')
+    .optional(),
+})
+
+export const ResolveGeographyFipsArgsSchema = {
+  type: 'object',
+  properties: {
+    geography_name: {
+      type: 'string',
+      description: 'The name of the Geography to resolve.',
+    },
+    summary_level: {
+      type: 'string',
+      description: 'The name or code of the Summary Level to search.',
+    },
+  },
+  required: ['geography_name'],
+}
+
+export type ResolveGeographyFipsArgs = z.infer<
+  typeof ResolveGeographyFipsInputSchema
+>

--- a/mcp-server/src/tools/fetch-dataset-geography.tool.ts
+++ b/mcp-server/src/tools/fetch-dataset-geography.tool.ts
@@ -54,9 +54,7 @@ export class FetchDatasetGeographyTool extends BaseTool<FetchDatasetGeographyArg
     return result.rows
   }
 
-  private buildGeographyMetadata(
-    levels: SummaryLevelRow[],
-  ): GeographyMetadata {
+  private buildGeographyMetadata(levels: SummaryLevelRow[]): GeographyMetadata {
     const metadata: GeographyMetadata = {}
 
     for (const level of levels) {

--- a/mcp-server/src/tools/identify-datasets.tool.ts
+++ b/mcp-server/src/tools/identify-datasets.tool.ts
@@ -6,17 +6,16 @@ import {
   AllDatasetMetadataJsonSchema,
   AllDatasetMetadataJsonResponseType,
   SimplifiedAPIDatasetType,
-  DatasetType
+  DatasetType,
 } from '../schema/identify-datasets.schema.js'
 
 import { BaseTool } from './base.tool.js'
 
 import { ToolContent } from '../types/base.types.js'
 
-export class IdentifyDatasetsTool extends BaseTool<object> { 
+export class IdentifyDatasetsTool extends BaseTool<object> {
   name = 'identify-datasets'
-  description = 
-  `This tool returns a data catalog of available Census datasets from the Census API. 
+  description = `This tool returns a data catalog of available Census datasets from the Census API. 
   The LLM should analyze this catalog against the user's request and identify the best dataset match(es).
   The LLM must return at least one dataset name or indicate low confidence if no dataset is a strong match. 
 
@@ -40,7 +39,7 @@ export class IdentifyDatasetsTool extends BaseTool<object> {
   }
 
   get argsSchema() {
-  return z.object({})
+    return z.object({})
   }
 
   constructor() {
@@ -48,7 +47,9 @@ export class IdentifyDatasetsTool extends BaseTool<object> {
     this.handler = this.handler.bind(this)
   }
 
-  private isValidMetadataResponse(data: unknown): data is AllDatasetMetadataJsonResponseType {
+  private isValidMetadataResponse(
+    data: unknown,
+  ): data is AllDatasetMetadataJsonResponseType {
     try {
       AllDatasetMetadataJsonSchema.parse(data)
       return true
@@ -59,14 +60,19 @@ export class IdentifyDatasetsTool extends BaseTool<object> {
 
   private simplifyDataset(dataset: DatasetType) {
     const simplified: SimplifiedAPIDatasetType = {
-      c_dataset: Array.isArray(dataset.c_dataset) ? dataset.c_dataset.join('/') : dataset.c_dataset,
+      c_dataset: Array.isArray(dataset.c_dataset)
+        ? dataset.c_dataset.join('/')
+        : dataset.c_dataset,
       title: dataset.title,
       description: dataset.description,
     }
     if ('c_vintage' in dataset) simplified.c_vintage = dataset.c_vintage
-    if ('c_isAggregate' in dataset) simplified.c_isAggregate = dataset.c_isAggregate
-    if ('c_isTimeseries' in dataset) simplified.c_isTimeseries = dataset.c_isTimeseries
-    if ('c_isMicrodata' in dataset) simplified.c_isMicrodata = dataset.c_isMicrodata
+    if ('c_isAggregate' in dataset)
+      simplified.c_isAggregate = dataset.c_isAggregate
+    if ('c_isTimeseries' in dataset)
+      simplified.c_isTimeseries = dataset.c_isTimeseries
+    if ('c_isMicrodata' in dataset)
+      simplified.c_isMicrodata = dataset.c_isMicrodata
     return simplified
   }
 
@@ -82,12 +88,16 @@ export class IdentifyDatasetsTool extends BaseTool<object> {
 
       const response = await fetch(catalogUrl)
       if (!response.ok) {
-        return this.createErrorResponse(`Failed to fetch catalog: ${response.status} ${response.statusText}`)
+        return this.createErrorResponse(
+          `Failed to fetch catalog: ${response.status} ${response.statusText}`,
+        )
       }
 
       const data = await response.json()
       if (!this.isValidMetadataResponse(data)) {
-        return this.createErrorResponse('Catalog response did not match expected metadata schema')
+        return this.createErrorResponse(
+          'Catalog response did not match expected metadata schema',
+        )
       }
 
       const simplified = data.dataset.map(this.simplifyDataset)
@@ -101,8 +111,11 @@ export class IdentifyDatasetsTool extends BaseTool<object> {
         ],
       }
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred'
-      return this.createErrorResponse(`Failed to fetch datasets: ${errorMessage}`)
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error occurred'
+      return this.createErrorResponse(
+        `Failed to fetch datasets: ${errorMessage}`,
+      )
     }
   }
 }

--- a/mcp-server/src/tools/resolve-geography-fips.tool.ts
+++ b/mcp-server/src/tools/resolve-geography-fips.tool.ts
@@ -1,0 +1,130 @@
+import { Tool } from '@modelcontextprotocol/sdk/types.js'
+
+import { BaseTool } from './base.tool.js'
+import { DatabaseService } from '../services/database.service.js'
+import {
+  ResolveGeographyFipsArgs,
+  ResolveGeographyFipsArgsSchema,
+  ResolveGeographyFipsInputSchema,
+} from '../schema/resolve-geography-fips.schema.js'
+
+import { GeographySearchResultRow } from '../types/geography.types.js'
+import { SummaryLevelRow } from '../types/summary-level.types.js'
+
+export const toolDescription = `
+	Provides potential matches for Census Bureau geographies. Includes Nation, Region, Division, and State-level 
+	geographies. For each result, it returns information about the geography, for and in parameters with the correct
+	FIPS code for constructing fetching data with other tools, and what years (vintages) the geography is available in.
+`
+
+export class ResolveGeographyFipsTool extends BaseTool<ResolveGeographyFipsArgsSchema> {
+  name = 'resolve-geography-fips'
+  description = toolDescription
+
+  private dbService: DatabaseService
+
+  inputSchema: Tool['inputSchema'] =
+    ResolveGeographyFipsArgsSchema as Tool['inputSchema']
+
+  get argsSchema() {
+    return ResolveGeographyFipsInputSchema
+  }
+
+  constructor() {
+    super()
+    this.handler = this.handler.bind(this)
+    this.dbService = DatabaseService.getInstance()
+  }
+
+  private async searchGeographiesBySummaryLevel(
+    query: string,
+    summary_level_code: string,
+  ): Promise<GeographySearchResultRow[]> {
+    const result = await this.dbService.query<GeographySearchResultRow>(
+      `SELECT * FROM search_geographies_by_summary_level($1, $2)`,
+      [query, summary_level_code],
+    )
+
+    return result.rows
+  }
+
+  private async searchGeographies(
+    query: string,
+  ): Promise<GeographySearchResultRow[]> {
+    const result = await this.dbService.query<GeographySearchResultRow>(
+      `SELECT * FROM search_geographies($1)`,
+      [query],
+    )
+
+    return result.rows
+  }
+
+  private async searchSummaryLevels(query: string): Promise<SummaryLevelRow[]> {
+    const result = await this.dbService.query<SummaryLevelRow>(
+      `SELECT * FROM search_summary_levels($1)`,
+      [query],
+    )
+
+    return result.rows
+  }
+
+  async handler(
+    args: ResolveGeographyFipsArgs,
+  ): Promise<{ content: ToolContent[] }> {
+    try {
+      // Check database health first
+      const isDbHealthy = await this.dbService.healthCheck()
+      if (!isDbHealthy) {
+        return this.createErrorResponse(
+          'Database connection failed - cannot retrieve geography metadata.',
+        )
+      }
+
+      let result
+
+      if (args.summary_level) {
+        const summary_levels = await this.searchSummaryLevels(
+          args.summary_level,
+        )
+
+        if (summary_levels.length > 0) {
+          result = await this.searchGeographiesBySummaryLevel(
+            args.geography_name,
+            summary_levels[0].code,
+          )
+        } else {
+          result = await this.searchGeographies(args.geography_name)
+        }
+      } else {
+        result = await this.searchGeographies(args.geography_name)
+      }
+
+      if (result && result.length > 0) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Found ${result.length} Matching Geographies:\n\n${JSON.stringify(result, null, 2)}`,
+            },
+          ],
+        }
+      } else {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `No geographies found matching "${args.geography_name}".`,
+            },
+          ],
+        }
+      }
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error occurred'
+
+      return this.createErrorResponse(
+        `Failed to resolve geography: ${errorMessage}`,
+      )
+    }
+  }
+}

--- a/mcp-server/src/types/base.types.ts
+++ b/mcp-server/src/types/base.types.ts
@@ -1,4 +1,4 @@
-import { TextContent, Tool} from '@modelcontextprotocol/sdk/types.js'
+import { TextContent, Tool } from '@modelcontextprotocol/sdk/types.js'
 import { z } from 'zod'
 
 type JsonContent = {

--- a/mcp-server/src/types/geography.types.ts
+++ b/mcp-server/src/types/geography.types.ts
@@ -1,0 +1,10 @@
+export interface GeographySearchResultRow {
+  id: number
+  name: text
+  summary_level_name: text
+  latitude: number
+  longitude: number
+  for_param: text
+  in_param: text
+  weighted_score: number
+}

--- a/mcp-server/tests/index.test.ts
+++ b/mcp-server/tests/index.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { MCPServer } from '../src/server'
 
-
 vi.mock('../src/tools/identify-datasets.tool.js', () => ({
   IdentifyDatasetsTool: vi
     .fn()
@@ -24,6 +23,12 @@ vi.mock('../src/tools/fetch-summary-table.tool.js', () => ({
   FetchSummaryTableTool: vi
     .fn()
     .mockImplementation(() => ({ name: 'fetch-summary-table-tool' })),
+}))
+
+vi.mock('../src/tools/resolve-geography-fips.tool.js', () => ({
+  ResolveGeographyFipsTool: vi
+    .fn()
+    .mockImplementation(() => ({ name: 'resolve-geography-fips-tool' })),
 }))
 
 vi.mock('@modelcontextprotocol/sdk/server/stdio.js', () => ({
@@ -53,7 +58,7 @@ describe('main', () => {
 
     await vi.importActual('../src/index.ts')
 
-    expect(serverSpy).toHaveBeenCalledTimes(4)
+    expect(serverSpy).toHaveBeenCalledTimes(5)
 
     expect(serverSpy).toHaveBeenCalledWith({ name: 'identify-datasets-tool' })
     expect(serverSpy).toHaveBeenCalledWith({
@@ -63,6 +68,9 @@ describe('main', () => {
       name: 'fetch-dataset-variables-tool',
     })
     expect(serverSpy).toHaveBeenCalledWith({ name: 'fetch-summary-table-tool' })
+    expect(serverSpy).toHaveBeenCalledWith({
+      name: 'resolve-geography-fips-tool',
+    })
 
     expect(StdioServerTransport).toHaveBeenCalledTimes(1)
     expect(connectSpy).toHaveBeenCalledTimes(1)

--- a/mcp-server/tests/schema/validators.test.ts
+++ b/mcp-server/tests/schema/validators.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { beforeEach, afterEach, describe, it, expect, vi } from 'vitest'
 import { RefinementCtx, z } from 'zod'
 
 import {

--- a/mcp-server/tests/server.test.ts
+++ b/mcp-server/tests/server.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { afterEach, describe, it, expect, beforeEach, vi } from 'vitest'
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js'
 import { Server } from '@modelcontextprotocol/sdk/server/index.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'

--- a/mcp-server/tests/tools/fetch-dataset-geography/fetch-dataset-geography.tool.test.ts
+++ b/mcp-server/tests/tools/fetch-dataset-geography/fetch-dataset-geography.tool.test.ts
@@ -113,7 +113,6 @@ describe('FetchDatasetGeographyTool', () => {
       healthCheck: vi.fn(),
       query: vi.fn(),
     }
-
     ;(DatabaseService.getInstance as Mock).mockReturnValue(mockDbService)
   })
 

--- a/mcp-server/tests/tools/identify-datasets/identify-datasets.tool.test.ts
+++ b/mcp-server/tests/tools/identify-datasets/identify-datasets.tool.test.ts
@@ -7,8 +7,7 @@ vi.mock('node-fetch', () => ({
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { IdentifyDatasetsTool } from '../../../src/tools/identify-datasets.tool'
-import { sampleDatasetMetadata } from '../../../tests/helpers/test-data' 
-
+import { sampleDatasetMetadata } from '../../../tests/helpers/test-data'
 
 describe('IdentifyDatasetsTool', () => {
   let tool: IdentifyDatasetsTool
@@ -17,7 +16,7 @@ describe('IdentifyDatasetsTool', () => {
     tool = new IdentifyDatasetsTool()
 
     mockFetch.mockClear()
-    
+
     delete process.env.CENSUS_API_KEY
   })
 
@@ -28,14 +27,16 @@ describe('IdentifyDatasetsTool', () => {
   describe('Tool Configuration', () => {
     it('should have correct name and description', () => {
       expect(tool.name).toBe('identify-datasets')
-      expect(tool.description).toContain('returns a data catalog of available Census datasets')
+      expect(tool.description).toContain(
+        'returns a data catalog of available Census datasets',
+      )
     })
 
     it('should have empty input schema', () => {
       expect(tool.inputSchema).toEqual({
         type: 'object',
         properties: {},
-        required: []
+        required: [],
       })
     })
 
@@ -48,26 +49,25 @@ describe('IdentifyDatasetsTool', () => {
   describe('Environment Variable Validation', () => {
     it('should return error when CENSUS_API_KEY is not set', async () => {
       const result = await tool.handler()
-      
+
       expect(result.content).toHaveLength(1)
       expect(result.content[0]).toEqual({
         type: 'text',
-        text: expect.stringContaining('CENSUS_API_KEY is not set')
+        text: expect.stringContaining('CENSUS_API_KEY is not set'),
       })
     })
 
     it('should return error when CENSUS_API_KEY is empty string', async () => {
       process.env.CENSUS_API_KEY = ''
-      
+
       const result = await tool.handler()
-      
+
       expect(result.content[0]).toEqual({
         type: 'text',
-        text: expect.stringContaining('CENSUS_API_KEY is not set')
+        text: expect.stringContaining('CENSUS_API_KEY is not set'),
       })
     })
   })
-
 
   describe('API Response Handling', () => {
     beforeEach(() => {
@@ -77,23 +77,26 @@ describe('IdentifyDatasetsTool', () => {
     it('should handle successful API response', async () => {
       mockFetch.mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve(sampleDatasetMetadata)
+        json: () => Promise.resolve(sampleDatasetMetadata),
       })
 
       const result = await tool.handler()
 
-      expect(mockFetch).toHaveBeenCalledWith('https://api.census.gov/data.json?key=test-api-key')
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.census.gov/data.json?key=test-api-key',
+      )
       expect(result.content).toHaveLength(1)
       expect(result.content[0].type).toBe('text')
-      
+
       const parsedContent = JSON.parse(result.content[0].text)
       expect(parsedContent).toHaveLength(1)
-      
+
       expect(parsedContent[0]).toEqual({
         c_dataset: 'acs/acs1',
         title: 'American Community Survey: 1-Year Estimates: Detailed Tables',
-        description: 'The American Community Survey (ACS) is an ongoing survey that provides vital information on a yearly basis about our nation and its people.',
-        c_vintage: 2022
+        description:
+          'The American Community Survey (ACS) is an ongoing survey that provides vital information on a yearly basis about our nation and its people.',
+        c_vintage: 2022,
       })
     })
 
@@ -101,14 +104,14 @@ describe('IdentifyDatasetsTool', () => {
       mockFetch.mockResolvedValue({
         ok: false,
         status: 403,
-        statusText: 'Forbidden'
+        statusText: 'Forbidden',
       })
 
       const result = await tool.handler()
 
       expect(result.content[0]).toEqual({
         type: 'text',
-        text: expect.stringContaining('Failed to fetch catalog: 403 Forbidden')
+        text: expect.stringContaining('Failed to fetch catalog: 403 Forbidden'),
       })
     })
 
@@ -119,7 +122,9 @@ describe('IdentifyDatasetsTool', () => {
 
       expect(result.content[0]).toEqual({
         type: 'text',
-        text: expect.stringContaining('Failed to fetch datasets: Network error')
+        text: expect.stringContaining(
+          'Failed to fetch datasets: Network error',
+        ),
       })
     })
 
@@ -130,7 +135,9 @@ describe('IdentifyDatasetsTool', () => {
 
       expect(result.content[0]).toEqual({
         type: 'text',
-        text: expect.stringContaining('Failed to fetch datasets: Unknown error occurred')
+        text: expect.stringContaining(
+          'Failed to fetch datasets: Unknown error occurred',
+        ),
       })
     })
   })
@@ -139,100 +146,107 @@ describe('IdentifyDatasetsTool', () => {
     beforeEach(() => {
       process.env.CENSUS_API_KEY = 'test-api-key'
     })
-    
+
     it('should handle invalid schema response', async () => {
       mockFetch.mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve({ invalidStructure: true })
+        json: () => Promise.resolve({ invalidStructure: true }),
       })
 
       const result = await tool.handler()
 
       expect(result.content[0]).toEqual({
         type: 'text',
-        text: expect.stringContaining('Catalog response did not match expected metadata schema')
+        text: expect.stringContaining(
+          'Catalog response did not match expected metadata schema',
+        ),
       })
 
       mockFetch.mockClear()
     })
-    
+
     it('should simplify dataset with array c_dataset', async () => {
       mockFetch.mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve(sampleDatasetMetadata)
+        json: () => Promise.resolve(sampleDatasetMetadata),
       })
-      
+
       const result = await tool.handler()
-      
+
       const parsedContent = JSON.parse(result.content[0].text)
-      
+
       expect(parsedContent[0].c_dataset).toBe('acs/acs1')
     })
 
     it('should simplify dataset with string c_dataset', async () => {
       const mockApiResponse = {
         ...sampleDatasetMetadata,
-        dataset: [{
-          c_vintage: 2010,
-          c_dataset: ["dec", "sf1"],
-          c_geographyLink: "http://api.census.gov/data/2010/dec/sf1/geography.json",
-          c_variablesLink: "http://api.census.gov/data/2010/dec/sf1/variables.json",
-          c_tagsLink: "http://api.census.gov/data/2010/dec/sf1/tags.json",
-          c_examplesLink: "http://api.census.gov/data/2010/dec/sf1/examples.json",
-          c_groupsLink: "http://api.census.gov/data/2010/dec/sf1/groups.json",
-          c_sorts_url: "http://api.census.gov/data/2010/dec/sf1/sorts.json",
-          c_documentationLink: "https://www.census.gov/developer/",
-          c_isAggregate: true,
-          c_isCube: true,
-          c_isAvailable: true,
-          "@type": "dcat:Dataset",
-          title: "Decennial SF1",
-          accessLevel: "public",
-          bureauCode: ["006:07"],
-          description: "Summary File 1 (SF 1) contains detailed tables...",
-          distribution: [
-            {
-              "@type": "dcat:Distribution",
-              accessURL: "http://api.census.gov/data/2010/dec/sf1",
-              description: "API endpoint",
-              format: "API",
-              mediaType: "application/json",
-              title: "API endpoint"
-            }
-          ],
-          contactPoint: {
-            fn: "Census Bureau Call Center",
-            hasEmail: "mailto:pio@census.gov"
-          },
-          identifier: "https://api.census.gov/data/id/DECENNIALSF12010",
-          keyword: ["census"],
-          license: "https://creativecommons.org/publicdomain/zero/1.0/",
-          modified: "2018-08-28 12:52:11.0",
-          programCode: ["006:004"],
-          references: ["https://www.census.gov/developers/"],
-          publisher: {
-            "@type": "org:Organization",
-            name: "U.S. Census Bureau",
-            subOrganizationOf: {
-              "@type": "org:Organization",
-              name: "U.S. Department Of Commerce",
+        dataset: [
+          {
+            c_vintage: 2010,
+            c_dataset: ['dec', 'sf1'],
+            c_geographyLink:
+              'http://api.census.gov/data/2010/dec/sf1/geography.json',
+            c_variablesLink:
+              'http://api.census.gov/data/2010/dec/sf1/variables.json',
+            c_tagsLink: 'http://api.census.gov/data/2010/dec/sf1/tags.json',
+            c_examplesLink:
+              'http://api.census.gov/data/2010/dec/sf1/examples.json',
+            c_groupsLink: 'http://api.census.gov/data/2010/dec/sf1/groups.json',
+            c_sorts_url: 'http://api.census.gov/data/2010/dec/sf1/sorts.json',
+            c_documentationLink: 'https://www.census.gov/developer/',
+            c_isAggregate: true,
+            c_isCube: true,
+            c_isAvailable: true,
+            '@type': 'dcat:Dataset',
+            title: 'Decennial SF1',
+            accessLevel: 'public',
+            bureauCode: ['006:07'],
+            description: 'Summary File 1 (SF 1) contains detailed tables...',
+            distribution: [
+              {
+                '@type': 'dcat:Distribution',
+                accessURL: 'http://api.census.gov/data/2010/dec/sf1',
+                description: 'API endpoint',
+                format: 'API',
+                mediaType: 'application/json',
+                title: 'API endpoint',
+              },
+            ],
+            contactPoint: {
+              fn: 'Census Bureau Call Center',
+              hasEmail: 'mailto:pio@census.gov',
+            },
+            identifier: 'https://api.census.gov/data/id/DECENNIALSF12010',
+            keyword: ['census'],
+            license: 'https://creativecommons.org/publicdomain/zero/1.0/',
+            modified: '2018-08-28 12:52:11.0',
+            programCode: ['006:004'],
+            references: ['https://www.census.gov/developers/'],
+            publisher: {
+              '@type': 'org:Organization',
+              name: 'U.S. Census Bureau',
               subOrganizationOf: {
-                "@type": "org:Organization",
-                name: "U.S. Government"
-              }
-            }
-          }
-        }]
+                '@type': 'org:Organization',
+                name: 'U.S. Department Of Commerce',
+                subOrganizationOf: {
+                  '@type': 'org:Organization',
+                  name: 'U.S. Government',
+                },
+              },
+            },
+          },
+        ],
       }
 
       mockFetch.mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve(mockApiResponse)
+        json: () => Promise.resolve(mockApiResponse),
       })
 
       const result = await tool.handler()
       const parsedContent = JSON.parse(result.content[0].text)
-      
+
       expect(parsedContent[0].c_dataset).toBe('dec/sf1')
     })
 
@@ -242,14 +256,14 @@ describe('IdentifyDatasetsTool', () => {
         dataset: [
           {
             ...sampleDatasetMetadata.dataset[0],
-            c_isAggregate: true
-          }
-        ]
+            c_isAggregate: true,
+          },
+        ],
       }
 
       mockFetch.mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve(mockApiResponse)
+        json: () => Promise.resolve(mockApiResponse),
       })
 
       const result = await tool.handler()
@@ -261,24 +275,24 @@ describe('IdentifyDatasetsTool', () => {
     it('should omit optional fields when not present', async () => {
       mockFetch.mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve(sampleDatasetMetadata)
+        json: () => Promise.resolve(sampleDatasetMetadata),
       })
 
       const result = await tool.handler()
       const parsedContent = JSON.parse(result.content[0].text)
-      
+
       expect(parsedContent[0]).not.toHaveProperty('c_isAggregate')
       expect(parsedContent[0]).not.toHaveProperty('c_isTimeseries')
       expect(parsedContent[0]).not.toHaveProperty('c_isMicrodata')
     })
 
     it('should return empty array when API returns no datasets', async () => {
-      const mockApiResponse = { ...sampleDatasetMetadata, dataset: [] };
+      const mockApiResponse = { ...sampleDatasetMetadata, dataset: [] }
 
       mockFetch.mockResolvedValue({
         ok: true,
-        json: async () => mockApiResponse
-      } as Response);
+        json: async () => mockApiResponse,
+      } as Response)
 
       const result = await tool.handler()
 
@@ -296,23 +310,25 @@ describe('IdentifyDatasetsTool', () => {
     it('should handle JSON parsing errors', async () => {
       mockFetch.mockResolvedValue({
         ok: true,
-        json: () => Promise.reject(new Error('Invalid JSON'))
+        json: () => Promise.reject(new Error('Invalid JSON')),
       })
 
       const result = await tool.handler()
 
       expect(result.content[0]).toEqual({
         type: 'text',
-        text: expect.stringContaining('Failed to fetch datasets: Invalid JSON')
+        text: expect.stringContaining('Failed to fetch datasets: Invalid JSON'),
       })
     })
   })
 
   describe('Constructor Binding', () => {
     it('should properly bind handler method', () => {
-
       // @ts-expect-error: spying on prototype method's bind isn't type-safe but is valid for testing
-      const handlerBindSpy = vi.spyOn(IdentifyDatasetsTool.prototype.handler, 'bind')
+      const handlerBindSpy = vi.spyOn(
+        IdentifyDatasetsTool.prototype.handler,
+        'bind',
+      )
       new IdentifyDatasetsTool()
 
       // This test ensures the handler is properly bound and won't lose context

--- a/mcp-server/tests/tools/resolve-geography-fips-tool/resolve-geography-fips-tool.integration.test.ts
+++ b/mcp-server/tests/tools/resolve-geography-fips-tool/resolve-geography-fips-tool.integration.test.ts
@@ -1,0 +1,94 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach,
+} from 'vitest'
+import { Client } from 'pg'
+
+import { DatabaseService } from '../../../src/services/database.service'
+import { databaseConfig } from '../../helpers/database-config'
+import { ResolveGeographyFipsTool } from '../../../src/tools/resolve-geography-fips.tool'
+
+describe('ResolveGeographyFipsTool - Integration Tests', () => {
+  let testClient: Client
+  let databaseService: DatabaseService
+  let tool: ResolveGeographyFipsTool
+
+  beforeAll(async () => {
+    // Use test database
+    testClient = new Client(databaseConfig)
+    await testClient.connect()
+    ;(
+      DatabaseService as typeof DatabaseService & { instance: unknown }
+    ).instance = undefined
+    databaseService = DatabaseService.getInstance()
+  })
+
+  afterAll(async () => {
+    await testClient.end()
+    await databaseService.cleanup()
+  })
+
+  afterEach(async () => {
+    // Clean up test data after each test
+    try {
+      console.log('Starting cleanup...')
+
+      // Clean up in correct dependency order (children first)
+      await testClient.query('DELETE FROM geographies WHERE true')
+      await testClient.query('DELETE FROM summary_levels WHERE true')
+
+      // Reset sequences
+      await testClient.query(
+        'ALTER SEQUENCE IF EXISTS geographies_id_seq RESTART WITH 1',
+      )
+      await testClient.query(
+        'ALTER SEQUENCE IF EXISTS summary_levels_id_seq RESTART WITH 1',
+      )
+
+      console.log('Cleanup completed successfully')
+    } catch (error) {
+      console.error('Cleanup failed:', error)
+      throw error
+    }
+  })
+
+  beforeEach(async () => {
+    tool = new ResolveGeographyFipsTool()
+
+    // Insert known test data
+    await testClient.query(`
+      INSERT INTO summary_levels (name, description, get_variable, query_name, on_spine, code, parent_summary_level)
+      VALUES 
+        ('Nation', 'The United States', 'NATION', 'us', true, '010', null),
+        ('State', 'States and State equivalents', 'STATE', 'state', true, '040', '030'),
+        ('Place', 'Census-designated places that meet population requirements', 'PLACE', 'place', false, '160 ', '040')
+    `)
+
+    await testClient.query(`
+      INSERT INTO geographies (name, summary_level_code, ucgid_code, latitude, longitude, state_code, county_code, for_param, in_param)
+      VALUES 
+        ('United States','010','0100000US','34.7366771','-103.2852703', null, null, 'us:*', null),
+        ('Pennsylvania','040','0400000US42','40.5869403','-77.3684875', '42', null, 'state:42', null),
+        ('Philadelphia city, Pennsylvania','160','1600000US4260000','40.0093755','-75.1333459', '42', null, 'place:60000', 'state:42')
+    `)
+  })
+
+  it('should return appropriately formatted content from the database', async () => {
+    const response = await tool.handler({
+      geography_name: 'Philadelphia',
+    })
+
+    expect(response.content[0].type).toBe('text')
+    const responseText = response.content[0].text
+
+    expect(responseText).toContain('Found 1 Matching Geographies:')
+    expect(responseText).toContain('Philadelphia city, Pennsylvania')
+    expect(responseText).toContain('"for_param": "place:60000')
+    expect(responseText).toContain('"in_param": "state:42"')
+  })
+})

--- a/mcp-server/tests/tools/resolve-geography-fips-tool/resolve-geography-fips-tool.test.ts
+++ b/mcp-server/tests/tools/resolve-geography-fips-tool/resolve-geography-fips-tool.test.ts
@@ -1,0 +1,261 @@
+// Mock DatabaseService
+vi.mock('../../../src/services/database.service.js', () => ({
+  DatabaseService: {
+    getInstance: vi.fn(),
+  },
+}))
+
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+  Mock,
+} from 'vitest'
+
+import {
+  validateResponseStructure,
+  validateToolStructure,
+} from '../../helpers/test-utils'
+
+import { DatabaseService } from '../../../src/services/database.service.js'
+import {
+  ResolveGeographyFipsTool,
+  toolDescription,
+} from '../../../src/tools/resolve-geography-fips.tool'
+
+const defaultArgs = {
+  geography_name: 'Philadelphia, Pennsylvania',
+}
+
+const summaryLevelArgs = {
+  ...defaultArgs,
+  summary_level: '160',
+}
+
+describe('ResolveGeographyFipsTool', () => {
+  let tool: ResolveGeographyFipsTool
+  let mockDbService: {
+    healthCheck: Mock
+    query: Mock
+  }
+
+  let mockSummaryLevels: SummaryLevelRow[]
+  let mockGeographies: GeographySearchResultRow[]
+
+  beforeAll(() => {
+    mockSummaryLevels = [
+      {
+        id: 1,
+        name: 'United States',
+        description: 'United States total',
+        get_variable: 'NATION',
+        query_name: 'us',
+        on_spine: true,
+        code: '010',
+        parent_summary_level: null,
+        parent_geography_level_id: null,
+      },
+      {
+        id: 2,
+        name: 'State',
+        description: 'States and State equivalents',
+        get_variable: 'STATE',
+        query_name: 'state',
+        on_spine: true,
+        code: '040',
+        parent_summary_level: '010',
+        parent_geography_level_id: 1,
+      },
+      {
+        id: 3,
+        name: 'County',
+        description: 'Counties and county equivalents',
+        get_variable: 'COUNTY',
+        query_name: 'county',
+        on_spine: true,
+        code: '050',
+        parent_summary_level: '040',
+        parent_geography_level_id: 2,
+      },
+    ]
+
+    mockDbService = {
+      healthCheck: vi.fn(),
+      query: vi.fn(),
+    }
+    ;(DatabaseService.getInstance as Mock).mockReturnValue(mockDbService)
+  })
+
+  beforeEach(() => {
+    mockDbService.healthCheck.mockReset().mockResolvedValue(true)
+    mockDbService.query
+      .mockReset()
+      .mockResolvedValue({ rows: mockSummaryLevels })
+
+    tool = new ResolveGeographyFipsTool()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should have the correct metadata', () => {
+    validateToolStructure(tool)
+    expect(tool.name).toBe('resolve-geography-fips')
+    expect(tool.description).toBe(toolDescription)
+  })
+
+  it('should have valid input schema', () => {
+    const schema = tool.inputSchema
+
+    expect(schema.type).toBe('object')
+    expect(schema.properties).toHaveProperty('geography_name')
+    expect(schema.properties).toHaveProperty('summary_level')
+    expect(schema.required).toEqual(['geography_name'])
+  })
+
+  it('should have matching args schema', () => {
+    expect(() => tool.argsSchema.parse(defaultArgs)).not.toThrow()
+  })
+
+  describe('Database Integration', () => {
+    it('should check database health', async () => {
+      await tool.handler(defaultArgs)
+
+      expect(mockDbService.healthCheck).toHaveBeenCalled()
+    })
+
+    it('should return error when database is unhealthy', async () => {
+      mockDbService.healthCheck.mockResolvedValue(false)
+
+      const response = await tool.handler(defaultArgs)
+      validateResponseStructure(response)
+      expect(response.content[0].text).toContain(
+        'Database connection failed - cannot retrieve geography metadata',
+      )
+    })
+
+    it('should handle database query errors', async () => {
+      mockDbService.query.mockRejectedValue(
+        new Error('Database connection failed'),
+      )
+
+      const response = await tool.handler(defaultArgs)
+      validateResponseStructure(response)
+      expect(response.content[0].text).toContain('Database connection failed')
+    })
+
+    describe('when only the geography_name is provided', () => {
+      it('should call search_geographies', async () => {
+        await tool.handler(defaultArgs)
+
+        // Verify the SQL query structure
+        const queryCall = mockDbService.query.mock.calls[0][0]
+        expect(queryCall).toContain('SELECT * FROM search_geographies($1)')
+      })
+    })
+
+    describe('when the geography_name and summary_level_code are provided', () => {
+      it('should call search_geographies_by_summary_level', async () => {
+        await tool.handler(summaryLevelArgs)
+
+        // Verify the SQL query structure
+        const queryCall1 = mockDbService.query.mock.calls[0][0]
+        const queryCall2 = mockDbService.query.mock.calls[1][0]
+        expect(queryCall1).toContain('SELECT * FROM search_summary_levels($1)')
+        expect(queryCall2).toContain(
+          'SELECT * FROM search_geographies_by_summary_level($1, $2)',
+        )
+      })
+    })
+  })
+
+  describe('Database Response Handling', () => {
+    describe('when the summary_levels search returns no summary_levels', () => {
+      it('calls search_geographies instead', async () => {
+        mockDbService.query.mockResolvedValue({ rows: [] })
+        await tool.handler(summaryLevelArgs)
+
+        const queryCall1 = mockDbService.query.mock.calls[0][0]
+        const queryCall2 = mockDbService.query.mock.calls[1][0]
+
+        expect(queryCall1).toContain('SELECT * FROM search_summary_levels($1)')
+        expect(queryCall2).toContain('SELECT * FROM search_geographies($1)')
+      })
+    })
+
+    describe('when there are geography results', () => {
+      it('returns the found geographies', async () => {
+        mockGeographies = [
+          {
+            id: 1,
+            name: 'Los Angeles',
+            summary_level_name: 'Place',
+            latitude: 34.0522,
+            longitude: -118.2437,
+            for_param: 'place:44000',
+            in_param: 'state:06',
+            weighted_score: 0.3,
+          },
+          {
+            id: 2,
+            name: 'Los Angeles County',
+            summary_level_name: 'County',
+            latitude: 34.0522,
+            longitude: -118.2437,
+            for_param: 'county:037',
+            in_param: 'state:06',
+            weighted_score: 0.4,
+          },
+        ]
+
+        mockDbService.query.mockResolvedValue({ rows: mockGeographies })
+
+        const result = await tool.handler({ geography_name: 'Los Angeles' })
+
+        expect(result.content).toHaveLength(1)
+        expect(result.content[0].type).toBe('text')
+        expect(result.content[0].text).toContain(
+          'Found 2 Matching Geographies:',
+        )
+        expect(result.content[0].text).toContain('Los Angeles')
+        expect(result.content[0].text).toContain('Los Angeles County')
+      })
+    })
+
+    describe('when there are no geography results', () => {
+      it('returns a message indicating no results', async () => {
+        mockDbService.query.mockResolvedValue({ rows: [] })
+
+        const result = await tool.handler({
+          geography_name: 'NonexistentPlace',
+        })
+
+        expect(result.content).toHaveLength(1)
+        expect(result.content[0].type).toBe('text')
+        expect(result.content[0].text).toContain(
+          'No geographies found matching "NonexistentPlace".',
+        )
+      })
+
+      it('includes summary level context when specified', async () => {
+        mockDbService.query
+          .mockResolvedValueOnce({ rows: [{ code: '050', name: 'County' }] }) // summary level found
+          .mockResolvedValueOnce({ rows: [] }) // no geographies found
+
+        const result = await tool.handler({
+          geography_name: 'NonexistentPlace',
+          summary_level: 'County',
+        })
+
+        expect(result.content[0].text).toContain(
+          'No geographies found matching "NonexistentPlace".',
+        )
+      })
+    })
+  })
+})

--- a/mcp-server/vitest.config.ts
+++ b/mcp-server/vitest.config.ts
@@ -5,9 +5,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    env: loadEnv('', process.cwd(), ''), // Load .env files
-    globalSetup: ['./tests/globalSetup.ts'],
-    setupFiles: ['./tests/setup.ts'],
+    env: loadEnv('', process.cwd(), ''),
     testTimeout: 10000,
     coverage: {
       reporter: ['text', 'json-summary', 'json'],
@@ -18,5 +16,44 @@ export default defineConfig({
         statements: 85,
       },
     },
+    projects: [
+      {
+        test: {
+          name: 'unit',
+          include: ['**/*.test.ts', '**/*.spec.ts'],
+          exclude: [
+            '**/*.integration.test.ts',
+            'node_modules/**',
+            'dist/**',
+            'build/**',
+          ],
+          pool: 'threads',
+          poolOptions: {
+            threads: {
+              singleThread: false,
+            },
+          },
+          globalSetup: ['./tests/globalSetup.ts'],
+          setupFiles: ['./tests/setup.ts'],
+        },
+      },
+      {
+        test: {
+          name: 'integration',
+          include: ['**/*.integration.test.ts'],
+          exclude: ['node_modules/**', 'dist/**', 'build/**'],
+          pool: 'forks',
+          poolOptions: {
+            forks: {
+              singleFork: true,
+            },
+          },
+          fileParallelism: false,
+          testTimeout: 30000,
+          globalSetup: ['./tests/globalSetup.ts'],
+          setupFiles: ['./tests/setup.ts'],
+        },
+      },
+    ],
   },
 })


### PR DESCRIPTION
Creates a tool for resolving Geography information based on an input provided by an LLM/user. Searches the locally seeded geographies using search functions to return a list of matching geographies designed to reduce token usage compared to the Census Data API.

* Create GeographyResolutionFips tool that utilizes search functions to return a list of geographies matching provided arguments
* Add migration that remove unused functions and creates new search functions to search summary_levels and geographies
* Separate integration and unit tests into different projects using different test thread rules to resolve conflicting test data