### PR TITLE
Add Selective Seeding for GitHub Workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,6 +85,9 @@ jobs:
   docker-prod-build:
     name: Docker Production Build Test
     runs-on: ubuntu-latest
+    env:
+      #Skip Time-consuming Seeding Operations Defined in seed-database 
+      SEED_MODE: slim
     
     steps:
       - uses: actions/checkout@v4
@@ -97,12 +100,15 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 3
-          command: docker compose --profile prod build --no-cache
+          command: SEED_MODE=$SEED_MODE docker compose --profile prod build --no-cache
     
       - name: Test production environment
         run: |
+          echo "=== Seeding Configuration ==="
+          echo "SEED_MODE: $SEED_MODE"
+
           echo "Starting production environment..."
-          docker compose --profile prod up -d
+          SEED_MODE=$SEED_MODE docker compose --profile prod up -d
           sleep 20
           
           echo "=== Production Container Status ==="

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
     environment:
       DATABASE_URL: postgresql://mcp_user:mcp_pass@census-mcp-db:5432/mcp_db
       NODE_ENV: production
+      SEED_MODE: ${SEED_MODE}
     depends_on:
       census-mcp-db:
         condition: service_healthy

--- a/mcp-db/src/seeds/scripts/seed-database.ts
+++ b/mcp-db/src/seeds/scripts/seed-database.ts
@@ -32,7 +32,8 @@ import {
 
 // Seed configurations
 export const seeds: SeedConfig[] = [SummaryLevelsConfig, YearsConfig]
-export const geographySeeds: EnhancedGeographySeedConfig[] = [
+
+let baseGeographySeeds: EnhancedGeographySeedConfig[] = [
   NationConfig,
   RegionConfig,
   DivisionConfig,
@@ -41,6 +42,17 @@ export const geographySeeds: EnhancedGeographySeedConfig[] = [
   CountySubdivisionConfig,
   PlaceConfig,
 ]
+
+export function geographySeeds(): EnhancedGeographySeedConfig[] {
+  if (process.env.SEED_MODE === 'slim') {
+    // Remove Configs That Take Forever to Run if SEED_MODE Set to Slim (For Testing Builds)
+    baseGeographySeeds = baseGeographySeeds
+      .filter((config) => config !== CountySubdivisionConfig)
+      .filter((config) => config !== PlaceConfig)
+  }
+
+  return baseGeographySeeds
+}
 
 export async function runSeeds(
   databaseUrl: string = DATABASE_URL,
@@ -57,7 +69,7 @@ export async function runSeeds(
     await runSeedsWithRunner(runner, targetSeedName)
 
     if (!targetSeedName) {
-      await runGeographySeeds(runner, geographySeeds)
+      await runGeographySeeds(runner, geographySeeds())
     }
 
     console.log('Seeding completed successfully!')
@@ -97,7 +109,7 @@ export async function runSeedsWithRunner(
 
 export async function runGeographySeeds(
   runner: SeedRunner,
-  seedConfigs: EnhancedGeographySeedConfig[] = geographySeeds,
+  seedConfigs: EnhancedGeographySeedConfig[] = geographySeeds(),
 ): Promise<void> {
   seedConfigs.forEach((config) => {
     validateGeographySeedConfig(config)

--- a/mcp-db/tests/seeds/scripts/seed-database.test.ts
+++ b/mcp-db/tests/seeds/scripts/seed-database.test.ts
@@ -35,12 +35,12 @@ import {
   YearsConfig,
 } from '../../../src/seeds/configs/index'
 import {
-  validateGeographyContext,
+  geographySeeds,
   runSeedsWithRunner,
   runSeeds,
   runGeographySeeds,
   seeds,
-  geographySeeds,
+  validateGeographyContext,
   zodErrorHandling,
 } from '../../../src/seeds/scripts/seed-database'
 
@@ -314,14 +314,21 @@ describe('Seed Database', () => {
 
   describe('geographySeeds', () => {
     it('includes geography configs', () => {
-      expect(geographySeeds).toHaveLength(7)
-      expect(geographySeeds).toContain(NationConfig)
-      expect(geographySeeds).toContain(RegionConfig)
-      expect(geographySeeds).toContain(DivisionConfig)
-      expect(geographySeeds).toContain(StateConfig)
-      expect(geographySeeds).toContain(CountyConfig)
-      expect(geographySeeds).toContain(CountySubdivisionConfig)
-      expect(geographySeeds).toContain(PlaceConfig)
+      expect(geographySeeds()).toHaveLength(7)
+      expect(geographySeeds()).toContain(NationConfig)
+      expect(geographySeeds()).toContain(RegionConfig)
+      expect(geographySeeds()).toContain(DivisionConfig)
+      expect(geographySeeds()).toContain(StateConfig)
+      expect(geographySeeds()).toContain(CountyConfig)
+      expect(geographySeeds()).toContain(CountySubdivisionConfig)
+      expect(geographySeeds()).toContain(PlaceConfig)
+    })
+
+    it('does not include time intensive configs when set to slim', () => {
+      process.env.SEED_MODE = 'slim'
+      expect(geographySeeds).not.toContain(CountySubdivisionConfig)
+      expect(geographySeeds).not.toContain(PlaceConfig)
+      delete process.env.SEED_MODE
     })
   })
 


### PR DESCRIPTION
Adds SEED_MODE env variable in GitHub Workflow to set strategy to slim for prod builds during testing.

* Add SEED_MODE env variable to the build action in GitHub
* Add logic to remove SeedConfigs that take too long to execute in seed-database for testing builds