### PR TITLE
Update README Documentation to Include Resolve Geography FIPS Tool Information

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ The `fetch-summary-table` tool is used for fetching a summary table from the Cen
 * Year (Required) - The vintage of the dataset, e.g. `1987`
 * Get (Required) - An object that is required that accepts 2 optional arguments:
 	* Variables (optional) - An array of variables for filtering responses by attributes and rows, e.g. `'NAME'`, `'B01001_001E'`
-	* Group (optional) - A string that returns a larger collecton of variables, e.g. `S0101`
+	* Group (Optional) - A string that returns a larger collecton of variables, e.g. `S0101`
 * For (Optional) - A string that testricts geography to various levels and is required in most datasets
 * In (Optional) - A string that restricts geography to smaller areas than state level
 * UCGID (Optional) - A string that restricts geography by Uniform Census Geography Identifier (UCGID), e.g. `0400000US41`
@@ -169,6 +169,17 @@ The `fetch-summary-table` tool is used for fetching a summary table from the Cen
 #### How to Run via CLI
 ```
 echo '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"fetch-summary-table","arguments":{"dataset":"acs/acs1","year":2022, "get": { "variables":["NAME","B01001_001E"] },"for":"state:01,13"}}}' \
+| docker exec -i mcp-server node dist/index.js
+```
+
+### Resolve Geography FIPS Tool
+The `resolve-geography-fips` tool is used to search across all Census Bureau geographies to return a list of potential matches and the correct FIPS codes and parameters used to query data in them. This tool accepts the following arguments:
+* Geography Name (Required) - The name of the geography to search, e.g. `Philadelphia`
+* Summary Level (Optional) - The summary level to search. Accepts name or summary level code, e.g. `Place`, `160`
+
+#### How to Run via CLI
+```
+echo '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"resolve-geography-fips","arguments":{"geography_name":"Philadelphia, Pennsylvania",}}}' \
 | docker exec -i mcp-server node dist/index.js
 ```
 

--- a/mcp-server/src/schema/resolve-geography-fips.schema.ts
+++ b/mcp-server/src/schema/resolve-geography-fips.schema.ts
@@ -13,11 +13,27 @@ export const ResolveGeographyFipsArgsSchema = {
   properties: {
     geography_name: {
       type: 'string',
-      description: 'The name of the Geography to resolve.',
+      description: 'The name of the geography to resolve.',
+      examples: [
+        'Philadelphia city, Pennsylvania',
+        'Philadelphia County, Pennsylvania',
+        'Philadelphia, Pennsylvania',
+        'Philadelphia'
+      ]
     },
     summary_level: {
       type: 'string',
-      description: 'The name or code of the Summary Level to search.',
+      description: 'Filters the geography resolution by the name or summary level code of a matching summary level.',
+      examples: [
+        'Place',
+        '160',
+        'County Subdivision',
+        'County',
+        'State',
+        '040',
+        'Division',
+        'Region',
+      ]
     },
   },
   required: ['geography_name'],

--- a/mcp-server/src/tools/resolve-geography-fips.tool.ts
+++ b/mcp-server/src/tools/resolve-geography-fips.tool.ts
@@ -13,7 +13,7 @@ import { SummaryLevelRow } from '../types/summary-level.types.js'
 import { ToolContent } from '../types/base.types.js'
 
 export const toolDescription = `
-	Provides potential matches for Census Bureau geographies. Includes Nation, Region, Division, and State-level 
+	Provides potential matches for Census Bureau geographies. Includes Nation, Region, Division, State, Counties, and County Subdivision 
 	geographies. For each result, it returns information about the geography, for and in parameters with the correct
 	FIPS code for constructing fetching data with other tools, and what years (vintages) the geography is available in.
 `

--- a/mcp-server/vitest.config.ts
+++ b/mcp-server/vitest.config.ts
@@ -50,6 +50,7 @@ export default defineConfig({
           },
           fileParallelism: false,
           testTimeout: 30000,
+          retry: 3,
           globalSetup: ['./tests/globalSetup.ts'],
           setupFiles: ['./tests/setup.ts'],
         },


### PR DESCRIPTION
Update README Documentation with code examples and instructions for the geo resolution tool.

* Update README content with Resolve Geography FIPS tool usage instructions.
* Update Resolve Geography FIPS input schema with example arguments.