### PR TITLE
Add Example of Predicates to Table Schema

### DIFF
--- a/mcp-server/src/schema/table.schema.ts
+++ b/mcp-server/src/schema/table.schema.ts
@@ -15,7 +15,10 @@ export const baseProperties = {
   predicates: {
     type: 'object',
     additionalProperties: { type: 'string' },
-    description: 'Used to filter table results.',
+    description: 'Used to filter table results with parameters outside of year and geography constraints.',
+    examples: [
+      { 'NAICS2017': '31-33', 'EPSZES': '251'}
+    ]
   },
 }
 


### PR DESCRIPTION
Adds a real example of a predicate to the table schema.

* Change predicate description and provide example to show how AI assistants should use this feature

Addresses https://github.com/uscensusbureau/us-census-bureau-data-api-mcp/issues/36