### PR TITLE
Refactor API Key Checks

### DIFF
--- a/mcp-server/src/tools/fetch-aggregate-data.tool.ts
+++ b/mcp-server/src/tools/fetch-aggregate-data.tool.ts
@@ -7,6 +7,7 @@ import {
   TableArgs,
   TableSchema,
 } from '../schema/fetch-aggregate-data.schema.js'
+import { ToolContent } from '../types/base.types.js'
 
 import {
   datasetValidator,
@@ -21,6 +22,7 @@ export class FetchAggregateDataTool extends BaseTool<TableArgs> {
   name = 'fetch-aggregate-data'
   description = toolDescription
   inputSchema: Tool['inputSchema'] = TableSchema as Tool['inputSchema']
+  readonly requiresApiKey = true
 
   get argsSchema() {
     return FetchAggregateDataToolSchema.superRefine((args, ctx) => {
@@ -48,12 +50,7 @@ export class FetchAggregateDataTool extends BaseTool<TableArgs> {
     return this.argsSchema.safeParse(input)
   }
 
-  async handler(args: TableArgs) {
-    const apiKey = process.env.CENSUS_API_KEY
-    if (!apiKey) {
-      return this.createErrorResponse('Error: CENSUS_API_KEY is not set.')
-    }
-
+  async toolHandler(args: TableArgs, apiKey: string): Promise<{ content: ToolContent[] }> {
     const baseUrl = `https://api.census.gov/data/${args.year}/${args.dataset}`
 
     let getParams = ''

--- a/mcp-server/src/tools/fetch-dataset-geography.tool.ts
+++ b/mcp-server/src/tools/fetch-dataset-geography.tool.ts
@@ -8,7 +8,6 @@ import {
   FetchDatasetGeographyInputSchema,
   GeographyJsonSchema,
 } from '../schema/dataset-geography.schema.js'
-
 import { ToolContent } from '../types/base.types.js'
 import {
   SummaryLevelRow,
@@ -19,6 +18,7 @@ import {
 export class FetchDatasetGeographyTool extends BaseTool<FetchDatasetGeographyArgs> {
   name = 'fetch-dataset-geography'
   description = 'Fetch available geographies for filtering a dataset.'
+  readonly requiresApiKey = true
 
   private dbService: DatabaseService
 
@@ -172,15 +172,8 @@ export class FetchDatasetGeographyTool extends BaseTool<FetchDatasetGeographyArg
       .join(' ')
   }
 
-  async handler(
-    args: FetchDatasetGeographyArgs,
-  ): Promise<{ content: ToolContent[] }> {
+  async toolHandler(args: FetchDatasetGeographyArgs, apiKey: string): Promise<{ content: ToolContent[] }> {
     try {
-      const apiKey = process.env.CENSUS_API_KEY
-      if (!apiKey) {
-        return this.createErrorResponse('Error: CENSUS_API_KEY is not set.')
-      }
-
       // Check database health first
       const isDbHealthy = await this.dbService.healthCheck()
       if (!isDbHealthy) {

--- a/mcp-server/src/tools/list-datasets.tool.ts
+++ b/mcp-server/src/tools/list-datasets.tool.ts
@@ -32,6 +32,7 @@ export class ListDatasetsTool extends BaseTool<object> {
     - If the user request is ambiguous, state your assumptions
     - Flag when no dataset is a strong match (confidence: 'low')
     `
+  readonly requiresApiKey = true
 
   inputSchema: Tool['inputSchema'] = {
     type: 'object',
@@ -142,13 +143,8 @@ export class ListDatasetsTool extends BaseTool<object> {
     return Array.from(grouped.values())
   }
 
-  async handler(): Promise<{ content: ToolContent[] }> {
+  async toolHandler(apiKey: string): Promise<{ content: ToolContent[] }> {
     try {
-      const apiKey = process.env.CENSUS_API_KEY
-      if (!apiKey) {
-        return this.createErrorResponse('CENSUS_API_KEY is not set')
-      }
-
       const fetch = (await import('node-fetch')).default
       const catalogUrl = `https://api.census.gov/data.json?key=${apiKey}`
 

--- a/mcp-server/src/tools/resolve-geography-fips.tool.ts
+++ b/mcp-server/src/tools/resolve-geography-fips.tool.ts
@@ -21,6 +21,7 @@ export const toolDescription = `
 export class ResolveGeographyFipsTool extends BaseTool<ResolveGeographyFipsArgs> {
   name = 'resolve-geography-fips'
   description = toolDescription
+  readonly requiresApiKey = false
 
   private dbService: DatabaseService
 
@@ -69,9 +70,7 @@ export class ResolveGeographyFipsTool extends BaseTool<ResolveGeographyFipsArgs>
     return result.rows
   }
 
-  async handler(
-    args: ResolveGeographyFipsArgs,
-  ): Promise<{ content: ToolContent[] }> {
+  async toolHandler(args: ResolveGeographyFipsArgs): Promise<{ content: ToolContent[] }> {
     try {
       // Check database health first
       const isDbHealthy = await this.dbService.healthCheck()

--- a/mcp-server/tests/tools/base/base.tool.test.ts
+++ b/mcp-server/tests/tools/base/base.tool.test.ts
@@ -1,0 +1,366 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { z } from 'zod'
+import { BaseTool } from '../../../src/tools/base.tool'
+import { ToolContent } from '../../../src/types/base.types'
+
+// Mock the process.env directly
+const originalEnv = process.env
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  process.env = originalEnv
+})
+
+class MockToolWithApiKey extends BaseTool<{ testArg: string }> {
+  name = 'mock-tool-with-api'
+  description = 'A mock tool that requires API key'
+  readonly requiresApiKey = true
+  inputSchema = {
+    type: 'object',
+    properties: {
+      testArg: { type: 'string' }
+    },
+    required: ['testArg']
+  }
+
+  get argsSchema() {
+    return z.object({
+      testArg: z.string()
+    })
+  }
+
+  protected async toolHandler(args: { testArg: string }, apiKey?: string): Promise<{ content: ToolContent[] }> {
+    return this.createSuccessResponse(`Executed with ${args.testArg} and key ${apiKey}`)
+  }
+}
+
+class MockToolWithoutApiKey extends BaseTool<{ testArg: string }> {
+  name = 'mock-tool-without-api'
+  description = 'A mock tool that does not require API key'
+  readonly requiresApiKey = false
+  inputSchema = {
+    type: 'object',
+    properties: {
+      testArg: { type: 'string' }
+    },
+    required: ['testArg']
+  }
+
+  get argsSchema() {
+    return z.object({
+      testArg: z.string()
+    })
+  }
+
+  protected async toolHandler(args: { testArg: string }): Promise<{ content: ToolContent[] }> {
+    return this.createSuccessResponse(`Executed with ${args.testArg} without API key`)
+  }
+}
+
+class ErrorThrowingToolWithApiKey extends BaseTool<{ testArg: string }> {
+  name = 'error-tool-with-api'
+  description = 'A tool that throws errors and requires API key'
+  readonly requiresApiKey = true
+  inputSchema = {
+    type: 'object',
+    properties: {
+      testArg: { type: 'string' }
+    },
+    required: ['testArg']
+  }
+
+  get argsSchema() {
+    return z.object({
+      testArg: z.string()
+    })
+  }
+
+  protected async toolHandler(args: { testArg: string }, apiKey?: string): Promise<{ content: ToolContent[] }> {
+    console.log(args, apiKey)
+    throw new Error('Test error from toolHandler method')
+  }
+}
+
+class ErrorThrowingToolWithoutApiKey extends BaseTool<{ testArg: string }> {
+  name = 'error-tool-without-api'
+  description = 'A tool that throws errors and does not require API key'
+  readonly requiresApiKey = false
+  inputSchema = {
+    type: 'object',
+    properties: {
+      testArg: { type: 'string' }
+    },
+    required: ['testArg']
+  }
+
+  get argsSchema() {
+    return z.object({
+      testArg: z.string()
+    })
+  }
+
+  protected async toolHandler(args: { testArg: string }, apiKey?: string): Promise<{ content: ToolContent[] }> {
+    console.log(args, apiKey)
+    throw new Error('Test error from toolHandler method')
+  }
+}
+
+describe('BaseTool', () => {
+  describe('handler', () => {
+    let mockToolWithApiKey: MockToolWithApiKey
+    let mockToolWithoutApiKey: MockToolWithoutApiKey
+    let errorToolWithApiKey: ErrorThrowingToolWithApiKey
+    let errorToolWithoutApiKey: ErrorThrowingToolWithoutApiKey
+
+    beforeEach(() => {
+      mockToolWithApiKey = new MockToolWithApiKey()
+      mockToolWithoutApiKey = new MockToolWithoutApiKey()
+      errorToolWithApiKey = new ErrorThrowingToolWithApiKey()
+      errorToolWithoutApiKey = new ErrorThrowingToolWithoutApiKey()
+    })
+
+    describe('API key validation for tools that require it', () => {
+      it('should return error response when CENSUS_API_KEY is not set', async () => {
+        // Mock process.env to not have the key
+        process.env = { ...originalEnv }
+        delete process.env.CENSUS_API_KEY
+
+        const result = await mockToolWithApiKey.handler({ testArg: 'test' })
+
+        expect(result).toEqual({
+          content: [{
+            type: 'text',
+            text: 'Error: CENSUS_API_KEY is not set.'
+          }]
+        })
+      })
+
+      it('should return error response when CENSUS_API_KEY is empty string', async () => {
+        // Mock process.env with empty string
+        process.env = { ...originalEnv, CENSUS_API_KEY: '' }
+
+        const result = await mockToolWithApiKey.handler({ testArg: 'test' })
+
+        expect(result).toEqual({
+          content: [{
+            type: 'text',
+            text: 'Error: CENSUS_API_KEY is not set.'
+          }]
+        })
+      })
+
+      it('should call toolHandler method when CENSUS_API_KEY is set', async () => {
+        // Mock process.env with a valid key
+        process.env = { ...originalEnv, CENSUS_API_KEY: 'test-api-key' }
+        
+        const result = await mockToolWithApiKey.handler({ testArg: 'test-value' })
+
+        expect(result).toEqual({
+          content: [{
+            type: 'text',
+            text: 'Executed with test-value and key test-api-key'
+          }]
+        })
+      })
+    })
+
+    describe('API key handling for tools that do not require it', () => {
+      it('should work without API key when requiresApiKey is false', async () => {
+        // Mock process.env to not have the key
+        process.env = { ...originalEnv }
+        delete process.env.CENSUS_API_KEY
+
+        const result = await mockToolWithoutApiKey.handler({ testArg: 'test' })
+
+        expect(result).toEqual({
+          content: [{
+            type: 'text',
+            text: 'Executed with test without API key'
+          }]
+        })
+      })
+
+      it('should work even when API key is present but not required', async () => {
+        // Mock process.env with a valid key (should be ignored)
+        process.env = { ...originalEnv, CENSUS_API_KEY: 'ignored-api-key' }
+        
+        const result = await mockToolWithoutApiKey.handler({ testArg: 'test-value' })
+
+        expect(result).toEqual({
+          content: [{
+            type: 'text',
+            text: 'Executed with test-value without API key'
+          }]
+        })
+      })
+    })
+
+    describe('error handling for tools with API key requirement', () => {
+      it('should catch and handle errors from toolHandler method', async () => {
+        process.env = { ...originalEnv, CENSUS_API_KEY: 'test-api-key' }
+
+        const result = await errorToolWithApiKey.handler({ testArg: 'test' })
+
+        expect(result).toEqual({
+          content: [{
+            type: 'text',
+            text: 'Unexpected error: Test error from toolHandler method'
+          }]
+        })
+      })
+    })
+
+    describe('error handling for tools without API key requirement', () => {
+      it('should catch and handle errors from toolHandler method', async () => {
+        // No API key needed
+        process.env = { ...originalEnv }
+        delete process.env.CENSUS_API_KEY
+
+        const result = await errorToolWithoutApiKey.handler({ testArg: 'test' })
+
+        expect(result).toEqual({
+          content: [{
+            type: 'text',
+            text: 'Unexpected error: Test error from toolHandler method'
+          }]
+        })
+      })
+    })
+
+    describe('error handling edge cases', () => {
+      it('should handle errors that do not have a message property', async () => {
+        class NonErrorThrowingTool extends BaseTool<{ testArg: string }> {
+          name = 'non-error-tool'
+          description = 'A tool that throws non-Error objects'
+          readonly requiresApiKey = false
+          inputSchema = {
+            type: 'object',
+            properties: {
+              testArg: { type: 'string' }
+            },
+            required: ['testArg']
+          }
+
+          get argsSchema() {
+            return z.object({
+              testArg: z.string()
+            })
+          }
+
+          protected async toolHandler(args: { testArg: string }, apiKey?: string): Promise<{ content: ToolContent[] }> {
+            console.log(args, apiKey)
+            throw 'String error'
+          }
+        }
+
+        const nonErrorTool = new NonErrorThrowingTool()
+        const result = await nonErrorTool.handler({ testArg: 'test' })
+
+        expect(result).toEqual({
+          content: [{
+            type: 'text',
+            text: 'Unexpected error: String error'
+          }]
+        })
+      })
+
+      it('should handle async errors properly', async () => {
+        class AsyncErrorTool extends BaseTool<{ testArg: string }> {
+          name = 'async-error-tool'
+          description = 'A tool that throws async errors'
+          readonly requiresApiKey = true
+          inputSchema = {
+            type: 'object',
+            properties: {
+              testArg: { type: 'string' }
+            },
+            required: ['testArg']
+          }
+
+          get argsSchema() {
+            return z.object({
+              testArg: z.string()
+            })
+          }
+
+          protected async toolHandler(args: { testArg: string }, apiKey?: string): Promise<{ content: ToolContent[] }> {
+            console.log(args, apiKey)
+            await new Promise(resolve => setTimeout(resolve, 10))
+            throw new Error('Async error')
+          }
+        }
+
+        process.env = { ...originalEnv, CENSUS_API_KEY: 'test-api-key' }
+        const asyncErrorTool = new AsyncErrorTool()
+
+        const result = await asyncErrorTool.handler({ testArg: 'test' })
+
+        expect(result).toEqual({
+          content: [{
+            type: 'text',
+            text: 'Unexpected error: Async error'
+          }]
+        })
+      })
+    })
+
+    describe('successful execution', () => {
+      it('should return success response from toolHandler method with API key', async () => {
+        process.env = { ...originalEnv, CENSUS_API_KEY: 'valid-key' }
+
+        const result = await mockToolWithApiKey.handler({ testArg: 'success-test' })
+
+        expect(result).toEqual({
+          content: [{
+            type: 'text',
+            text: 'Executed with success-test and key valid-key'
+          }]
+        })
+      })
+
+      it('should return success response from toolHandler method without API key', async () => {
+        // No API key set or needed
+        process.env = { ...originalEnv }
+        delete process.env.CENSUS_API_KEY
+
+        const result = await mockToolWithoutApiKey.handler({ testArg: 'success-test' })
+
+        expect(result).toEqual({
+          content: [{
+            type: 'text',
+            text: 'Executed with success-test without API key'
+          }]
+        })
+      })
+
+      it('should pass correct arguments to toolHandler method', async () => {
+        process.env = { ...originalEnv, CENSUS_API_KEY: 'test-key-123' }
+        
+        const testArgs = { testArg: 'complex-test-value' }
+        const result = await mockToolWithApiKey.handler(testArgs)
+
+        expect(result).toEqual({
+          content: [{
+            type: 'text',
+            text: 'Executed with complex-test-value and key test-key-123'
+          }]
+        })
+      })
+    })
+
+    describe('requiresApiKey property behavior', () => {
+      it('should correctly identify tools that require API keys', () => {
+        expect(mockToolWithApiKey.requiresApiKey).toBe(true)
+        expect(errorToolWithApiKey.requiresApiKey).toBe(true)
+      })
+
+      it('should correctly identify tools that do not require API keys', () => {
+        expect(mockToolWithoutApiKey.requiresApiKey).toBe(false)
+        expect(errorToolWithoutApiKey.requiresApiKey).toBe(false)
+      })
+    })
+  })
+})

--- a/mcp-server/tests/tools/fetch-aggregate-data/fetch-aggregate-data.tool.integration.test.ts
+++ b/mcp-server/tests/tools/fetch-aggregate-data/fetch-aggregate-data.tool.integration.test.ts
@@ -7,14 +7,14 @@ describe('FetchAggregateDataTool - Integration Tests', () => {
     const datasetName = 'acs/acs1'
     const groupName = 'B17015'
 
-    const response = await tool.handler({
+    const response = await tool.toolHandler({
       dataset: datasetName,
       year: 2022,
       get: {
         group: groupName,
       },
       for: 'state:*',
-    })
+    }, process.env.CENSUS_API_KEY)
 
     expect(response.content[0].type).toBe('text')
     const responseText = response.content[0].text
@@ -27,7 +27,7 @@ describe('FetchAggregateDataTool - Integration Tests', () => {
     const datasetName = 'acs/acs5'
     const groupName = 'B15003'
 
-    const response = await tool.handler({
+    const response = await tool.toolHandler({
       dataset: datasetName,
       year: 2022,
       get: {
@@ -35,26 +35,11 @@ describe('FetchAggregateDataTool - Integration Tests', () => {
       },
       for: 'tract:*',
       in: 'state:17 county:031',
-    })
+    }, process.env.CENSUS_API_KEY)
 
     expect(response.content[0].type).toBe('text')
     const responseText = response.content[0].text
     expect(responseText).toContain(`${datasetName}`)
     expect(responseText).toContain(`${groupName}`)
   }, 10000) // Longer timeout for real API calls
-
-  it('should handle real API errors gracefully', async () => {
-    const tool = new FetchAggregateDataTool()
-
-    const response = await tool.handler({
-      dataset: 'nonexistent/dataset',
-      year: 2022,
-      get: {
-        group: 'B18014',
-      },
-    })
-
-    expect(response.content[0].type).toBe('text')
-    expect(response.content[0].text).toContain('Census API error: 404 ')
-  }, 10000)
 })

--- a/mcp-server/tests/tools/fetch-dataset-geography/fetch-dataset-geography.tool.test.ts
+++ b/mcp-server/tests/tools/fetch-dataset-geography/fetch-dataset-geography.tool.test.ts
@@ -140,6 +140,7 @@ describe('FetchDatasetGeographyTool', () => {
       expect(tool.description).toBe(
         'Fetch available geographies for filtering a dataset.',
       )
+      expect(tool.requiresApiKey).toBe(true)
     })
 
     it('should have valid input schema', () => {
@@ -183,41 +184,6 @@ describe('FetchDatasetGeographyTool', () => {
     })
   })
 
-  describe('API Key Handling', () => {
-    it('should return error when API key is missing', async () => {
-      const originalApiKey = process.env.CENSUS_API_KEY
-      delete process.env.CENSUS_API_KEY
-
-      const args = {
-        dataset: 'acs/acs1',
-        year: 2022,
-      }
-
-      const response = await tool.handler(args)
-      validateResponseStructure(response)
-      expect(response.content[0].text).toContain('CENSUS_API_KEY is not set')
-
-      // Restore API key for other tests
-      process.env.CENSUS_API_KEY = originalApiKey
-    })
-
-    it('should use API key when available', async () => {
-      mockFetch.mockResolvedValue(createMockResponse(mockCensusApiResponse))
-      const apiKey = process.env.CENSUS_API_KEY
-
-      const args = {
-        dataset: 'acs/acs1',
-        year: 2022,
-      }
-
-      await tool.handler(args)
-
-      expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining(`key=${apiKey}`),
-      )
-    })
-  })
-
   describe('Database Integration', () => {
     it('should return error when database is unhealthy', async () => {
       mockDbService.healthCheck.mockResolvedValue(false)
@@ -227,7 +193,7 @@ describe('FetchDatasetGeographyTool', () => {
         year: 2022,
       }
 
-      const response = await tool.handler(args)
+      const response = await tool.toolHandler(args, process.env.CENSUS_API_KEY)
       validateResponseStructure(response)
       expect(response.content[0].text).toContain(
         'Database connection failed - cannot retrieve geography metadata',
@@ -242,7 +208,7 @@ describe('FetchDatasetGeographyTool', () => {
         year: 2022,
       }
 
-      await tool.handler(args)
+      await tool.toolHandler(args, process.env.CENSUS_API_KEY)
 
       expect(mockDbService.healthCheck).toHaveBeenCalled()
 
@@ -262,7 +228,7 @@ describe('FetchDatasetGeographyTool', () => {
         year: 2022,
       }
 
-      const response = await tool.handler(args)
+      const response = await tool.toolHandler(args, process.env.CENSUS_API_KEY)
       validateResponseStructure(response)
       expect(response.content[0].text).toContain('Database connection failed')
     })
@@ -277,7 +243,7 @@ describe('FetchDatasetGeographyTool', () => {
         year: 2022,
       }
 
-      await tool.handler(args)
+      await tool.toolHandler(args, process.env.CENSUS_API_KEY)
       const calls = mockFetch.mock.calls
       expect(calls[0][0]).toContain(
         'https://api.census.gov/data/2022/acs/acs1/geography.json?key=',
@@ -291,7 +257,7 @@ describe('FetchDatasetGeographyTool', () => {
         dataset: 'timeseries/asm/area2012',
       }
 
-      await tool.handler(args)
+      await tool.toolHandler(args, process.env.CENSUS_API_KEY)
 
       expect(mockFetch).toHaveBeenCalledWith(
         expect.stringContaining(
@@ -310,7 +276,7 @@ describe('FetchDatasetGeographyTool', () => {
         year: 2022,
       }
 
-      const response = await tool.handler(args)
+      const response = await tool.toolHandler(args, process.env.CENSUS_API_KEY)
       validateResponseStructure(response)
 
       expect(response.content[0].type).toBe('text')
@@ -367,7 +333,7 @@ describe('FetchDatasetGeographyTool', () => {
         year: 2022,
       }
 
-      const response = await tool.handler(args)
+      const response = await tool.toolHandler(args, process.env.CENSUS_API_KEY)
       validateResponseStructure(response)
 
       const responseText = response.content[0].text
@@ -393,7 +359,7 @@ describe('FetchDatasetGeographyTool', () => {
         year: 2022,
       }
 
-      const response = await tool.handler(args)
+      const response = await tool.toolHandler(args, process.env.CENSUS_API_KEY)
       validateResponseStructure(response)
       expect(response.content[0].text).toContain(
         'Geography endpoint returned: 400 Bad Request',
@@ -408,7 +374,7 @@ describe('FetchDatasetGeographyTool', () => {
         year: 2022,
       }
 
-      const response = await tool.handler(args)
+      const response = await tool.toolHandler(args, process.env.CENSUS_API_KEY)
       validateResponseStructure(response)
       expect(response.content[0].text).toContain(
         'Failed to fetch dataset geography levels: Network error',
@@ -426,7 +392,7 @@ describe('FetchDatasetGeographyTool', () => {
         year: 2022,
       }
 
-      const response = await tool.handler(args)
+      const response = await tool.toolHandler(args, process.env.CENSUS_API_KEY)
       validateResponseStructure(response)
       expect(response.content[0].text).toContain(
         'Failed to fetch dataset geography levels: Invalid JSON',
@@ -442,7 +408,7 @@ describe('FetchDatasetGeographyTool', () => {
         year: 2022,
       }
 
-      const response = await tool.handler(args)
+      const response = await tool.toolHandler(args, process.env.CENSUS_API_KEY)
       validateResponseStructure(response)
       expect(response.content[0].text).toContain('Response validation failed')
     })
@@ -457,7 +423,7 @@ describe('FetchDatasetGeographyTool', () => {
         year: 2022,
       }
 
-      const response = await tool.handler(args)
+      const response = await tool.toolHandler(args, process.env.CENSUS_API_KEY)
       const responseText = response.content[0].text
       const jsonStart = responseText.indexOf('[')
       const parsedData = JSON.parse(responseText.substring(jsonStart))
@@ -480,7 +446,7 @@ describe('FetchDatasetGeographyTool', () => {
         year: 2022,
       }
 
-      const response = await tool.handler(args)
+      const response = await tool.toolHandler(args, process.env.CENSUS_API_KEY)
       const responseText = response.content[0].text
       const jsonStart = responseText.indexOf('[')
       const parsedData = JSON.parse(responseText.substring(jsonStart))

--- a/mcp-server/tests/tools/fetch-dataset-geography/fetch-dataset.geography.tool.integration.test.ts
+++ b/mcp-server/tests/tools/fetch-dataset-geography/fetch-dataset.geography.tool.integration.test.ts
@@ -133,7 +133,7 @@ describe('FetchDatasetGeographyTool - Integration Tests', () => {
 
       const brokenTool = new FetchDatasetGeographyTool()
 
-      const response = await brokenTool.handler({ dataset: 'acs/acs1' })
+      const response = await brokenTool.toolHandler({ dataset: 'acs/acs1' }, process.env.CENSUS_API_KEY)
 
       expect(response.content[0].text).toContain('Database connection failed')
 
@@ -154,7 +154,7 @@ describe('FetchDatasetGeographyTool - Integration Tests', () => {
 
       global.fetch = mockFetch
 
-      const response = await tool.handler({ dataset: 'acs/acs1' })
+      const response = await tool.toolHandler({ dataset: 'acs/acs1' }, process.env.CENSUS_API_KEY)
 
       expect(response.content[0].type).toBe('text')
       const responseText = response.content[0].text
@@ -167,10 +167,10 @@ describe('FetchDatasetGeographyTool - Integration Tests', () => {
     it('should fetch real ACS geography metadata with database enhancement', async () => {
       const datasetName = 'acs/acs1'
 
-      const response = await tool.handler({
+      const response = await tool.toolHandler({
         dataset: datasetName,
         year: 2022,
-      })
+      }, process.env.CENSUS_API_KEY)
 
       expect(response.content[0].type).toBe('text')
       const responseText = response.content[0].text
@@ -211,23 +211,12 @@ describe('FetchDatasetGeographyTool - Integration Tests', () => {
       }
     }, 15000) // Extended timeout for real API calls
 
-    it('should handle real API errors gracefully', async () => {
-      const response = await tool.handler({
-        dataset: 'nonexistent/dataset',
-      })
-
-      expect(response.content[0].type).toBe('text')
-      expect(response.content[0].text).toContain(
-        'Geography endpoint returned: 404',
-      )
-    }, 10000)
-
     it('should work with timeseries datasets', async () => {
       const datasetName = 'timeseries/healthins/sahie'
 
-      const response = await tool.handler({
+      const response = await tool.toolHandler({
         dataset: datasetName,
-      })
+      }, process.env.CENSUS_API_KEY)
 
       expect(response.content[0].type).toBe('text')
       const responseText = response.content[0].text
@@ -267,7 +256,7 @@ describe('FetchDatasetGeographyTool - Integration Tests', () => {
 
       global.fetch = mockFetch
 
-      const response = await tool.handler({ dataset: 'acs/acs1', year: '2022' })
+      const response = await tool.toolHandler({ dataset: 'acs/acs1', year: '2022' }, process.env.CENSUS_API_KEY)
 
       const responseText = response.content[0].text
       const jsonStart = responseText.indexOf('[')
@@ -323,7 +312,7 @@ describe('FetchDatasetGeographyTool - Integration Tests', () => {
 
       global.fetch = mockFetch
 
-      const response = await tool.handler({ dataset: 'acs/acs1', year: '2022' })
+      const response = await tool.toolHandler({ dataset: 'acs/acs1', year: '2022' }, process.env.CENSUS_API_KEY)
 
       const responseText = response.content[0].text
       const jsonStart = responseText.indexOf('[')
@@ -362,7 +351,7 @@ describe('FetchDatasetGeographyTool - Integration Tests', () => {
 
       global.fetch = mockFetch
 
-      const response = await tool.handler({ dataset: 'acs/acs1', year: '2022' })
+      const response = await tool.toolHandler({ dataset: 'acs/acs1', year: '2022' }, process.env.CENSUS_API_KEY)
 
       const responseText = response.content[0].text
       const jsonStart = responseText.indexOf('[')

--- a/mcp-server/tests/tools/list-datasets/list-datasets.tool.integration.test.ts
+++ b/mcp-server/tests/tools/list-datasets/list-datasets.tool.integration.test.ts
@@ -5,7 +5,7 @@ describe('ListDatasetsTool - Integration Tests', () => {
   it('should fetch and process real Census dataset metadata', async () => {
     const tool = new ListDatasetsTool()
 
-    const response = await tool.handler()
+    const response = await tool.toolHandler(process.env.CENSUS_API_KEY)
 
     expect(response.content[0].type).toBe('text')
     const responseText = response.content[0].text

--- a/mcp-server/tests/tools/resolve-geography-fips/resolve-geography-fips-tool.test.ts
+++ b/mcp-server/tests/tools/resolve-geography-fips/resolve-geography-fips-tool.test.ts
@@ -107,6 +107,7 @@ describe('ResolveGeographyFipsTool', () => {
     validateToolStructure(tool)
     expect(tool.name).toBe('resolve-geography-fips')
     expect(tool.description).toBe(toolDescription)
+    expect(tool.requiresApiKey).toBe(false)
   })
 
   it('should have valid input schema', () => {


### PR DESCRIPTION
Refactors the API Check in all tools to use the BaseTool instead of repeating check logic in each tool.

* Remove API Checks from each tool
* Add API Check logic to BaseTool
* Remove API Check tests from each tool
* Add BaseTool checks for API key logic and functions

Resolves https://github.com/uscensusbureau/us-census-bureau-data-api-mcp/issues/73