### PR TITLE
Added prompt documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ To run tests, navigate to the `mcp-db/` directoruy and run `npm run test:db`.
 
 ## Available Methods
 
-The MCP server exposes several methods: `tools/list`, `tools/call`, `prompts/list`, and `prompts/gets`.
+The MCP server exposes several methods: `tools/list`, `tools/call`, `prompts/list`, and `prompts/get`.
 
 ## Listing Tools
 


### PR DESCRIPTION
**What**: Added prompt documentation to README (and changed Resources to Additional Information, to clarify that this heading isn't referring to the MCP Resources primitive). 