### PR TITLE
Create List Survey Programs Tool

### DIFF
--- a/mcp-db/migrations/1773071716018_create-programs-and-components-search-functions.ts
+++ b/mcp-db/migrations/1773071716018_create-programs-and-components-search-functions.ts
@@ -56,8 +56,7 @@ export const listSurveyProgramsSQL = `
     program_label  TEXT,
     program_string VARCHAR(15),
     description    TEXT,
-    table_count    INT,
-    searchable     BOOLEAN
+    table_count    INT
   )
   LANGUAGE sql STABLE
   AS $$
@@ -78,8 +77,7 @@ export const listSurveyProgramsSQL = `
           LIMIT  1
         )
       )                                                          AS description,
-      COUNT(DISTINCT dt.id)::INT                                 AS table_count,
-      COUNT(DISTINCT dt.id) > 0                                  AS searchable
+      COUNT(DISTINCT dt.id)::INT                                 AS table_count
     FROM  programs p
     LEFT  JOIN components          c   ON c.program_id   = p.id
     LEFT  JOIN datasets            d   ON d.component_id = c.id

--- a/mcp-server/eslint.config.js
+++ b/mcp-server/eslint.config.js
@@ -15,4 +15,14 @@ export default defineConfig([
     languageOptions: { globals: globals.node },
   },
   tseslint.configs.recommended,
+  {
+    files: ['**/*.{ts,mts,cts}'],
+    rules: {
+      '@typescript-eslint/no-unused-vars': ['error', {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        caughtErrorsIgnorePattern: '^_',
+      }],
+    },
+  },
 ])

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -7,7 +7,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "inspect": "npx @modelcontextprotocol/inspector node dist/index.js",
-    "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
+    "lint": "eslint . --ext .js,.jsx,.ts,.tsx --ignore-pattern dist/ --ignore-pattern build/",
     "prepare": "npm run build",
     "test": "vitest --printConsoleTrace=true --silent=false",
     "test:coverage": "vitest --coverage",

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -12,6 +12,7 @@ import { MCPServer } from './server.js'
 import { FetchAggregateDataTool } from './tools/fetch-aggregate-data.tool.js'
 import { FetchDatasetGeographyTool } from './tools/fetch-dataset-geography.tool.js'
 import { ListDatasetsTool } from './tools/list-datasets.tool.js'
+import { ListSurveyProgramsTool } from './tools/list-survey-programs.tool.js'
 import { ResolveGeographyFipsTool } from './tools/resolve-geography-fips.tool.js'
 import { SearchDataTablesTool } from './tools/search-data-tables.tool.js'
 
@@ -28,6 +29,7 @@ async function main() {
   mcpServer.registerTool(new FetchAggregateDataTool())
   mcpServer.registerTool(new FetchDatasetGeographyTool())
   mcpServer.registerTool(new ListDatasetsTool())
+  mcpServer.registerTool(new ListSurveyProgramsTool())
   mcpServer.registerTool(new ResolveGeographyFipsTool())
   mcpServer.registerTool(new SearchDataTablesTool())
 

--- a/mcp-server/src/schema/list-survey-programs.schema.ts
+++ b/mcp-server/src/schema/list-survey-programs.schema.ts
@@ -1,0 +1,4 @@
+import { z } from 'zod'
+
+export const ListSurveyProgramsInputSchema = z.object({})
+export type ListSurveyProgramsArgs = z.infer<typeof ListSurveyProgramsInputSchema>

--- a/mcp-server/src/tools/list-survey-programs.tool.ts
+++ b/mcp-server/src/tools/list-survey-programs.tool.ts
@@ -1,0 +1,98 @@
+import { Tool } from '@modelcontextprotocol/sdk/types.js'
+
+import { BaseTool } from './base.tool.js'
+import { DatabaseService } from '../services/database.service.js'
+import {
+  ListSurveyProgramsArgs,
+  ListSurveyProgramsInputSchema,
+} from '../schema/list-survey-programs.schema.js'
+import { SurveyProgramRow } from '../types/survey-program.types.js'
+import { ToolContent } from '../types/base.types.js'
+
+export const toolDescription = `
+  Returns a complete index of all Census Bureau survey programs available in this MCP server. Use this tool at the start of a session or to determine what data is available, which surveys are covered, and how to find a dataset. No input arguments are required.
+
+  Each result object includes:
+  - program_label: human-readable name of the program (e.g., "American Community Survey")
+  - program_string: short acronym used to identify the program (e.g., "ACS")
+  - description: brief orientation text describing the program's scope and methodology
+  - table_count: number of indexed data tables available for this program
+
+  Programs without tables have no indexed tables — use fetch-aggregate-data with known variable names for those programs instead.
+  Table coverage summary: ACS (~83%), CPS (~14%), SIPP (~3%). Decennial Census, Population Estimates, and Decennial Census of Island Areas have limited coverage. Economic Census, Economic Surveys, Geography, Census Planning Database, and several other programs have no indexed tables.
+`
+
+export class ListSurveyProgramsTool extends BaseTool<ListSurveyProgramsArgs> {
+  name = 'list-survey-programs'
+  description = toolDescription
+  readonly requiresApiKey = false
+
+  private dbService: DatabaseService
+
+  inputSchema: Tool['inputSchema'] = {
+    type: 'object',
+    properties: {},
+    required: [],
+  }
+
+  get argsSchema() {
+    return ListSurveyProgramsInputSchema
+  }
+
+  constructor() {
+    super()
+    this.handler = this.handler.bind(this)
+    this.dbService = DatabaseService.getInstance()
+  }
+
+  private async listSurveyPrograms(): Promise<SurveyProgramRow[]> {
+    const result = await this.dbService.query<SurveyProgramRow>(
+      `SELECT * FROM list_survey_programs()`,
+      [],
+    )
+
+    return result.rows
+  }
+
+  async toolHandler(
+    _args: ListSurveyProgramsArgs,
+  ): Promise<{ content: ToolContent[] }> {
+    try {
+      const isDbHealthy = await this.dbService.healthCheck()
+      if (!isDbHealthy) {
+        return this.createErrorResponse(
+          'Database connection failed - cannot list survey programs.',
+        )
+      }
+
+      const results = await this.listSurveyPrograms()
+
+      if (results && results.length > 0) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Found ${results.length} Survey Program${results.length === 1 ? '' : 's'}:\n\n${JSON.stringify(results, null, 2)}`,
+            },
+          ],
+        }
+      } else {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: 'No survey programs found.',
+            },
+          ],
+        }
+      }
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error occurred'
+
+      return this.createErrorResponse(
+        `Failed to list survey programs: ${errorMessage}`,
+      )
+    }
+  }
+}

--- a/mcp-server/src/types/survey-program.types.ts
+++ b/mcp-server/src/types/survey-program.types.ts
@@ -1,0 +1,6 @@
+export interface SurveyProgramRow {
+  program_label: string
+  program_string: string
+  description: string | null
+  table_count: number
+}

--- a/mcp-server/tests/helpers/get-response-text.ts
+++ b/mcp-server/tests/helpers/get-response-text.ts
@@ -1,0 +1,12 @@
+export function getResponseText(
+  response: { content: Array<{ type: string; text?: string }> },
+  index = 0,
+): string {
+  const item = response.content[index]
+  if (item.type !== 'text') {
+    throw new Error(
+      `Expected content[${index}] to be type "text", got "${item.type}"`,
+    )
+  }
+  return (item as { type: 'text'; text: string }).text
+}

--- a/mcp-server/tests/index.test.ts
+++ b/mcp-server/tests/index.test.ts
@@ -15,6 +15,12 @@ vi.mock('../src/tools/list-datasets.tool.js', () => ({
     .mockImplementation(() => ({ name: 'list-datasets' })),
 }))
 
+vi.mock('../src/tools/list-survey-programs.tool.js', () => ({
+  ListSurveyProgramsTool: vi
+    .fn()
+    .mockImplementation(() => ({ name: 'list-survey-programs' })),
+}))
+
 vi.mock('../src/tools/fetch-dataset-geography.tool.js', () => ({
   FetchDatasetGeographyTool: vi
     .fn()
@@ -75,7 +81,7 @@ describe('main', () => {
       name: 'population-prompt',
     })
 
-    expect(toolRegistrySpy).toHaveBeenCalledTimes(5)
+    expect(toolRegistrySpy).toHaveBeenCalledTimes(6)
 
     expect(toolRegistrySpy).toHaveBeenCalledWith({
       name: 'fetch-aggregate-data',
@@ -84,6 +90,11 @@ describe('main', () => {
     expect(toolRegistrySpy).toHaveBeenCalledWith({
       name: 'list-datasets',
     })
+
+    expect(toolRegistrySpy).toHaveBeenCalledWith({
+      name: 'list-survey-programs',
+    })
+
     expect(toolRegistrySpy).toHaveBeenCalledWith({
       name: 'fetch-dataset-geography',
     })

--- a/mcp-server/tests/schema/list-survey-programs.schema.test.ts
+++ b/mcp-server/tests/schema/list-survey-programs.schema.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import { ListSurveyProgramsInputSchema } from '../../src/schema/list-survey-programs.schema'
+
+describe('ListSurveyProgramsInputSchema', () => {
+  it('should accept an empty object', () => {
+    expect(() => ListSurveyProgramsInputSchema.parse({})).not.toThrow()
+  })
+
+  it('should ignore unknown keys', () => {
+    expect(() =>
+      ListSurveyProgramsInputSchema.parse({ unexpected: 'value' }),
+    ).not.toThrow()
+  })
+})

--- a/mcp-server/tests/tools/list-survey-programs/list-survey-programs.integration.test.ts
+++ b/mcp-server/tests/tools/list-survey-programs/list-survey-programs.integration.test.ts
@@ -1,0 +1,203 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach,
+} from 'vitest'
+import { Client } from 'pg'
+
+import { DatabaseService } from '../../../src/services/database.service'
+import { databaseConfig } from '../../helpers/database-config'
+import { getResponseText } from '../../helpers/get-response-text.js'
+import { ListSurveyProgramsTool } from '../../../src/tools/list-survey-programs.tool'
+
+describe('ListSurveyProgramsTool - Integration Tests', () => {
+  let testClient: Client
+  let databaseService: DatabaseService
+  let tool: ListSurveyProgramsTool
+
+  beforeAll(async () => {
+    testClient = new Client(databaseConfig)
+    await testClient.connect()
+    ;(DatabaseService as unknown as { instance: unknown }).instance = undefined
+    databaseService = DatabaseService.getInstance()
+  })
+
+  afterAll(async () => {
+    await testClient.end()
+    await databaseService.cleanup()
+  })
+
+  afterEach(async () => {
+    await testClient.query('DELETE FROM data_table_datasets WHERE true')
+    await testClient.query('DELETE FROM data_tables WHERE true')
+    await testClient.query('DELETE FROM datasets WHERE true')
+    await testClient.query('DELETE FROM years WHERE true')
+    await testClient.query('DELETE FROM components WHERE true')
+    await testClient.query('DELETE FROM programs WHERE true')
+
+    await testClient.query(
+      'ALTER SEQUENCE IF EXISTS data_table_datasets_id_seq RESTART WITH 1',
+    )
+    await testClient.query(
+      'ALTER SEQUENCE IF EXISTS data_tables_id_seq RESTART WITH 1',
+    )
+    await testClient.query(
+      'ALTER SEQUENCE IF EXISTS datasets_id_seq RESTART WITH 1',
+    )
+    await testClient.query(
+      'ALTER SEQUENCE IF EXISTS years_id_seq RESTART WITH 1',
+    )
+    await testClient.query(
+      'ALTER SEQUENCE IF EXISTS components_id_seq RESTART WITH 1',
+    )
+    await testClient.query(
+      'ALTER SEQUENCE IF EXISTS programs_id_seq RESTART WITH 1',
+    )
+  })
+
+  beforeEach(async () => {
+    tool = new ListSurveyProgramsTool()
+
+    await testClient.query(`
+      INSERT INTO programs (acronym, label, description)
+      VALUES
+        ('ACS', 'American Community Survey', 'Ongoing survey providing annual demographic, social, economic, and housing data.'),
+        ('ECN', 'Economic Census', 'Official five-year measure of American business and the economy.')
+    `)
+
+    await testClient.query(`
+      INSERT INTO components (label, api_endpoint, description, component_id, program_id)
+      VALUES (
+        'ACS 1-Year Estimates',
+        'acs/acs1',
+        'ACS 1-Year Estimates',
+        'ACS1',
+        (SELECT id FROM programs WHERE acronym = 'ACS')
+      )
+    `)
+
+    await testClient.query(`
+      INSERT INTO years (year) VALUES (2022)
+    `)
+
+    await testClient.query(`
+      INSERT INTO datasets (dataset_id, name, description, type, api_endpoint, year_id, component_id)
+      VALUES (
+        'ACSY2022',
+        'ACS 1-Year 2022',
+        'ACS 1-Year Detailed Tables 2022',
+        'aggregate',
+        'acs/acs1',
+        (SELECT id FROM years WHERE year = 2022),
+        (SELECT id FROM components WHERE api_endpoint = 'acs/acs1')
+      )
+    `)
+
+    await testClient.query(`
+      INSERT INTO data_tables (data_table_id, label)
+      VALUES ('B01001', 'Sex By Age')
+    `)
+
+    await testClient.query(`
+      INSERT INTO data_table_datasets (data_table_id, dataset_id, label)
+      VALUES (
+        (SELECT id FROM data_tables WHERE data_table_id = 'B01001'),
+        (SELECT id FROM datasets WHERE dataset_id = 'ACSY2022'),
+        'Sex By Age'
+      )
+    `)
+  })
+
+  it('returns all seeded programs', async () => {
+    const response = await tool.handler({})
+    const text = getResponseText(response)
+
+    expect(text).toContain('Found 2 Survey Programs:')
+    expect(text).toContain('American Community Survey')
+    expect(text).toContain('Economic Census')
+  })
+
+  it('returns programs ordered alphabetically by label', async () => {
+    const response = await tool.handler({})
+    const text = getResponseText(response)
+    const parsed = JSON.parse(text.split('\n\n')[1])
+
+    const labels = parsed.map((p: { program_label: string }) => p.program_label)
+    expect(labels).toEqual([...labels].sort())
+  })
+
+  it('reflects correct table_count for a program with indexed tables', async () => {
+    const response = await tool.handler({})
+    const text = getResponseText(response)
+    const parsed = JSON.parse(text.split('\n\n')[1])
+
+    const acs = parsed.find((p: { program_string: string }) => p.program_string === 'ACS')
+    expect(acs.table_count).toBe(1)
+  })
+
+  it('reflects table_count of 0 for a program with no indexed tables', async () => {
+    const response = await tool.handler({})
+    const text = getResponseText(response)
+    const parsed = JSON.parse(text.split('\n\n')[1])
+
+    const ecn = parsed.find((p: { program_string: string }) => p.program_string === 'ECN')
+    expect(ecn.table_count).toBe(0)
+  })
+
+  it('includes description for programs with an explicit description', async () => {
+    const response = await tool.handler({})
+    const text = getResponseText(response)
+    const parsed = JSON.parse(text.split('\n\n')[1])
+
+    const acs = parsed.find((p: { program_string: string }) => p.program_string === 'ACS')
+    expect(acs.description).toBe(
+      'Ongoing survey providing annual demographic, social, economic, and housing data.',
+    )
+  })
+
+  it('falls back to component description when program description is absent', async () => {
+    // Seed a program with no description but a component that has one
+    await testClient.query(`
+      INSERT INTO programs (acronym, label)
+      VALUES ('CPS', 'Current Population Survey')
+    `)
+    await testClient.query(`
+      INSERT INTO components (label, api_endpoint, description, component_id, program_id)
+      VALUES (
+        'CPS Basic Monthly',
+        'cps/basic/nov',
+        'Monthly survey of households conducted for the Bureau of Labor Statistics.',
+        'CPSBASIC',
+        (SELECT id FROM programs WHERE acronym = 'CPS')
+      )
+    `)
+
+    const response = await tool.handler({})
+    const text = getResponseText(response)
+    const parsed = JSON.parse(text.split('\n\n')[1])
+
+    const cps = parsed.find((p: { program_string: string }) => p.program_string === 'CPS')
+    expect(cps.description).toBe(
+      'Monthly survey of households conducted for the Bureau of Labor Statistics.',
+    )
+  })
+
+  it('returns a no-results message when the programs table is empty', async () => {
+    // Clear all data seeded in beforeEach
+    await testClient.query('DELETE FROM data_table_datasets WHERE true')
+    await testClient.query('DELETE FROM data_tables WHERE true')
+    await testClient.query('DELETE FROM datasets WHERE true')
+    await testClient.query('DELETE FROM years WHERE true')
+    await testClient.query('DELETE FROM components WHERE true')
+    await testClient.query('DELETE FROM programs WHERE true')
+
+    const response = await tool.handler({})
+    const text = getResponseText(response)
+
+    expect(text).toBe('No survey programs found.')
+  })
+})

--- a/mcp-server/tests/tools/list-survey-programs/list-survey-programs.unit.test.ts
+++ b/mcp-server/tests/tools/list-survey-programs/list-survey-programs.unit.test.ts
@@ -1,0 +1,198 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+  Mock,
+} from 'vitest'
+import { TextContent } from '@modelcontextprotocol/sdk/types.js'
+
+vi.mock('../../../src/services/database.service.js', () => ({
+  DatabaseService: {
+    getInstance: vi.fn(),
+  },
+}))
+
+import { validateToolStructure } from '../../helpers/test-utils'
+
+import { DatabaseService } from '../../../src/services/database.service.js'
+import {
+  ListSurveyProgramsTool,
+  toolDescription,
+} from '../../../src/tools/list-survey-programs.tool'
+import { SurveyProgramRow } from '../../../src/types/survey-program.types'
+
+const mockSurveyPrograms: SurveyProgramRow[] = [
+  {
+    program_label: 'American Community Survey',
+    program_string: 'ACS',
+    description:
+      'Ongoing survey providing annual demographic, social, economic, and housing data for communities across the United States.',
+    table_count: 1200,
+    searchable: true,
+  },
+  {
+    program_label: 'Current Population Survey',
+    program_string: 'CPS',
+    description:
+      'Monthly survey of households conducted by the Census Bureau for the Bureau of Labor Statistics.',
+    table_count: 300,
+    searchable: true,
+  },
+  {
+    program_label: 'Economic Census',
+    program_string: 'ECN',
+    description:
+      'Official five-year measure of American business and the economy.',
+    table_count: 0,
+    searchable: false,
+  },
+]
+
+function getTextContent(
+  response: Awaited<ReturnType<ListSurveyProgramsTool['handler']>>,
+  index = 0,
+): TextContent {
+  const item = response.content[index]
+  if (item.type !== 'text') {
+    throw new Error(
+      `Expected content[${index}] to be type "text", got "${item.type}"`,
+    )
+  }
+  return item as TextContent
+}
+
+describe('ListSurveyProgramsTool', () => {
+  let tool: ListSurveyProgramsTool
+  let mockDbService: {
+    healthCheck: Mock
+    query: Mock
+  }
+
+  beforeAll(() => {
+    mockDbService = {
+      healthCheck: vi.fn(),
+      query: vi.fn(),
+    }
+    ;(DatabaseService.getInstance as Mock).mockReturnValue(mockDbService)
+  })
+
+  beforeEach(() => {
+    mockDbService.healthCheck.mockReset().mockResolvedValue(true)
+    mockDbService.query.mockReset().mockResolvedValue({ rows: mockSurveyPrograms })
+
+    tool = new ListSurveyProgramsTool()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should have the correct metadata', () => {
+    validateToolStructure(tool)
+    expect(tool.name).toBe('list-survey-programs')
+    expect(tool.description).toBe(toolDescription)
+    expect(tool.requiresApiKey).toBe(false)
+  })
+
+  it('should have a valid input schema with no properties or required fields', () => {
+    const schema = tool.inputSchema
+
+    expect(schema.type).toBe('object')
+    expect(schema.properties).toEqual({})
+    expect(schema.required).toEqual([])
+  })
+
+  describe('args schema validation', () => {
+    it('should accept an empty object', () => {
+      expect(() => tool.argsSchema.parse({})).not.toThrow()
+    })
+
+    it('should ignore unknown keys', () => {
+      expect(() =>
+        tool.argsSchema.parse({ unexpected: 'value' }),
+      ).not.toThrow()
+    })
+  })
+
+  describe('Response Handling', () => {
+    describe('when results are found', () => {
+      it('returns all survey programs', async () => {
+        const result = await tool.handler({})
+
+        expect(result.content).toHaveLength(1)
+        expect(result.content[0].type).toBe('text')
+        expect(getTextContent(result).text).toContain(
+          'Found 3 Survey Programs:',
+        )
+        expect(getTextContent(result).text).toContain('American Community Survey')
+        expect(getTextContent(result).text).toContain('Current Population Survey')
+        expect(getTextContent(result).text).toContain('Economic Census')
+      })
+
+      it('uses singular form when exactly one result is returned', async () => {
+        mockDbService.query.mockResolvedValue({ rows: [mockSurveyPrograms[0]] })
+
+        const result = await tool.handler({})
+
+        expect(getTextContent(result).text).toContain('Found 1 Survey Program:')
+        expect(getTextContent(result).text).not.toContain('Survey Programs:')
+      })
+
+      it('serialises all fields for each program', async () => {
+        const result = await tool.handler({})
+        const parsed = JSON.parse(getTextContent(result).text.split('\n\n')[1])
+
+        const acs = parsed.find(
+          (p: SurveyProgramRow) => p.program_string === 'ACS',
+        )
+        expect(acs.program_label).toBe('American Community Survey')
+        expect(acs.table_count).toBe(1200)
+        expect(acs.searchable).toBe(true)
+      })
+
+      it('correctly reflects searchable: false for programs without indexed tables', async () => {
+        const result = await tool.handler({})
+        const parsed = JSON.parse(getTextContent(result).text.split('\n\n')[1])
+
+        const ecn = parsed.find(
+          (p: SurveyProgramRow) => p.program_string === 'ECN',
+        )
+        expect(ecn.table_count).toBe(0)
+        expect(ecn.searchable).toBe(false)
+      })
+
+      it('handles null description gracefully', async () => {
+        const programWithNullDescription: SurveyProgramRow = {
+          ...mockSurveyPrograms[0],
+          description: null,
+        }
+        mockDbService.query.mockResolvedValue({
+          rows: [programWithNullDescription],
+        })
+
+        const result = await tool.handler({})
+        const parsed = JSON.parse(getTextContent(result).text.split('\n\n')[1])
+
+        expect(parsed[0].description).toBeNull()
+      })
+    })
+
+    describe('when no results are found', () => {
+      beforeEach(() => {
+        mockDbService.query.mockResolvedValue({ rows: [] })
+      })
+
+      it('returns a no-results message', async () => {
+        const result = await tool.handler({})
+
+        expect(getTextContent(result).text).toBe(
+          'No survey programs found.',
+        )
+      })
+    })
+  })
+})

--- a/mcp-server/tests/tools/search-data-tables/search-data-tables.tool.integration.test.ts
+++ b/mcp-server/tests/tools/search-data-tables/search-data-tables.tool.integration.test.ts
@@ -11,17 +11,8 @@ import { Client } from 'pg'
 
 import { DatabaseService } from '../../../src/services/database.service'
 import { databaseConfig } from '../../helpers/database-config'
+import { getResponseText } from '../../helpers/get-response-text.js'
 import { SearchDataTablesTool } from '../../../src/tools/search-data-tables.tool'
-
-function getResponseText(
-  response: Awaited<ReturnType<SearchDataTablesTool['handler']>>,
-): string {
-  const item = response.content[0]
-  if (item.type !== 'text') {
-    throw new Error(`Expected text content, got "${item.type}"`)
-  }
-  return (item as { type: 'text'; text: string }).text
-}
 
 describe('SearchDataTablesTool - Integration Tests', () => {
   let testClient: Client


### PR DESCRIPTION
Creates a list-survey-programs tool to assist with survey identification prior to fetch tool calls. This is part of a broader update to provide a set of tools that provide better context and richer details while improving token counts (compared to list-datasets).

* Create list-survey-programs tool for listing survey programs
* Add list-survey-programs tool to ToolRegistry for listing on start