### PR TITLE
Update examples in `descriptive` property to use boolean type

### DIFF
--- a/mcp-server/src/schema/table.schema.ts
+++ b/mcp-server/src/schema/table.schema.ts
@@ -10,7 +10,7 @@ export const baseProperties = {
   descriptive: {
     type: 'boolean',
     description: 'Add variable labels to the second row of the API results.',
-    examples: ['true', 'false'],
+    examples: [true, false],
   },
   predicates: {
     type: 'object',


### PR DESCRIPTION
**Describe the bug**
In `mcp-server/src/schema/table.schema.ts`, the `descriptive` property is defined to expect a `boolean` type, but the provided examples use strings:
```
 descriptive: {
    type: 'boolean',   <-- expect boolean
    description: 'Add variable labels to the second row of the API results.',
    examples: ['true', 'false'],    <-- examples are strings
  },
```

This causes an `invalid_type` error when the strings `'true'` or `'false'` are passed to the MCP (`fetch-aggregate-data`):
```
# Arguments:
{
  "dataset": "acs/acs1/profile",
  "year": 2023,
  "get": {
    "variables": [
      "DP05_0001E"
    ]
  },
  "for": "state:06",
  "descriptive": 'true'
}
```

```
mcp.shared.exceptions.McpError: MCP error -32602: Invalid arguments: [
  {
    "code": "invalid_type",
    "expected": "boolean",
    "received": "string",
    "path": [
      "descriptive"
    ],
    "message": "Expected boolean, received string"
  }
]
```

**Conversation:**
"What is the population of California"

**Model Details**
 - Model: gpt-5-mini
 - Where the Conversation Occured: local development using the MCP (python)

**Fix**
This issue was fixed simply by updating the examples to be true boolean values (`[true, false]`)
```
 descriptive: {
    type: 'boolean',
    description: 'Add variable labels to the second row of the API results.',
    examples: [true, false],    <-- use boolean types in examples
  },
```

