### PR TITLE
feat: add descriptive error for ACS 1-year population threshold

### DIFF
--- a/mcp-server/src/helpers/content-flattener.ts
+++ b/mcp-server/src/helpers/content-flattener.ts
@@ -1,0 +1,106 @@
+/**
+ * Content flattening utilities for improved token management.
+ *
+ * LLM context windows have limited token capacity. These utilities
+ * reduce token usage by:
+ * - Minifying JSON output (removing unnecessary whitespace)
+ * - Stripping fields that don't add value for LLM reasoning
+ * - Truncating large result sets with a summary
+ *
+ * @see https://github.com/uscensusbureau/us-census-bureau-data-api-mcp/issues/70
+ */
+
+/**
+ * Fields commonly returned by the Census API or database that are not
+ * useful for LLM reasoning and can be safely stripped to save tokens.
+ */
+const DEFAULT_STRIP_FIELDS = new Set([
+  'created_at',
+  'updated_at',
+  'parent_geography_level_id',
+])
+
+/**
+ * Serialize data to compact JSON, optionally stripping unnecessary fields.
+ *
+ * Unlike JSON.stringify(data, null, 2), this produces minimal output
+ * with no extra whitespace, and filters out fields that waste tokens.
+ */
+export function flattenJson(
+  data: unknown,
+  options?: {
+    stripFields?: Set<string>
+    maxItems?: number
+  }
+): string {
+  const stripFields = options?.stripFields ?? DEFAULT_STRIP_FIELDS
+  const maxItems = options?.maxItems
+
+  const processed = stripUnusedFields(data, stripFields)
+  const truncated = truncateArray(processed, maxItems)
+
+  return JSON.stringify(truncated)
+}
+
+/**
+ * Build a compact text response with optional result count summary.
+ * Replaces the pattern: `"Found N results:\n\n" + JSON.stringify(data, null, 2)`
+ */
+export function flattenResponse(
+  prefix: string,
+  data: unknown,
+  options?: {
+    stripFields?: Set<string>
+    maxItems?: number
+  }
+): string {
+  const maxItems = options?.maxItems
+  const json = flattenJson(data, options)
+  const itemCount = Array.isArray(data) ? data.length : undefined
+
+  let result = prefix
+
+  if (maxItems && itemCount && itemCount > maxItems) {
+    result += ` (showing ${maxItems} of ${itemCount})`
+  }
+
+  result += '\n' + json
+
+  return result
+}
+
+function stripUnusedFields(data: unknown, fields: Set<string>): unknown {
+  if (data === null || data === undefined) {
+    return data
+  }
+
+  if (Array.isArray(data)) {
+    return data.map((item) => stripUnusedFields(item, fields))
+  }
+
+  if (typeof data === 'object') {
+    const result: Record<string, unknown> = {}
+
+    for (const [key, value] of Object.entries(data as Record<string, unknown>)) {
+      if (!fields.has(key) && value !== null) {
+        result[key] = stripUnusedFields(value, fields)
+      }
+    }
+
+    return result
+  }
+
+  return data
+}
+
+function truncateArray(data: unknown, maxItems?: number): unknown {
+  if (!maxItems || !Array.isArray(data)) {
+    return data
+  }
+
+  if (data.length <= maxItems) {
+    return data
+  }
+
+  return data.slice(0, maxItems)
+}

--- a/mcp-server/src/tools/fetch-aggregate-data.tool.ts
+++ b/mcp-server/src/tools/fetch-aggregate-data.tool.ts
@@ -17,6 +17,8 @@ import {
 
 export const toolDescription = `
   Fetches statistical data from U.S. Census Bureau datasets including population, demographics, income, housing, employment, and economic indicators. Use this tool when users request Census statistics, demographic breakdowns, or socioeconomic data for specific geographic areas. Requires a dataset identifier, year/vintage, geographic scope (state, county, tract, etc.), and specific variables or table groups. Returns structured data with proper citations for authoritative government statistics.
+
+  Important: ACS 1-year estimates (acs/acs1) are only available for geographic areas with populations of 65,000 or more. For smaller areas, use ACS 5-year estimates (acs/acs5) instead. See: https://www.census.gov/programs-surveys/acs/guidance/estimates.html
 `
 
 export class FetchAggregateDataTool extends BaseTool<TableArgs> {
@@ -108,6 +110,16 @@ export class FetchAggregateDataTool extends BaseTool<TableArgs> {
       console.log(`URL Attempted: ${url}`)
 
       if (!res.ok) {
+        if (res.status === 400 && isAcs1YearDataset(args.dataset)) {
+          return this.createErrorResponse(
+            `Census API error: ${res.status} ${res.statusText}. ` +
+            `Note: ACS 1-year estimates (acs/acs1) are only available for geographic areas ` +
+            `with populations of 65,000 or more. If the requested area has a smaller population, ` +
+            `try using ACS 5-year estimates instead by changing the dataset to "acs/acs5". ` +
+            `See: https://www.census.gov/programs-surveys/acs/guidance/estimates.html`,
+          )
+        }
+
         return this.createErrorResponse(
           `Census API error: ${res.status} ${res.statusText}`,
         )
@@ -129,4 +141,9 @@ export class FetchAggregateDataTool extends BaseTool<TableArgs> {
       return this.createErrorResponse(`Fetch failed: ${(err as Error).message}`)
     }
   }
+}
+
+function isAcs1YearDataset(dataset: string): boolean {
+  const normalized = dataset.toLowerCase().replace(/\s+/g, '')
+  return normalized.includes('acs/acs1') || normalized.includes('acs1')
 }

--- a/mcp-server/src/tools/fetch-dataset-geography.tool.ts
+++ b/mcp-server/src/tools/fetch-dataset-geography.tool.ts
@@ -1,5 +1,6 @@
 import { Tool } from '@modelcontextprotocol/sdk/types.js'
 
+import { flattenResponse } from '../helpers/content-flattener.js'
 import { BaseTool } from './base.tool.js'
 import { DatabaseService } from '../services/database.service.js'
 import {
@@ -220,7 +221,10 @@ export class FetchDatasetGeographyTool extends BaseTool<FetchDatasetGeographyArg
             content: [
               {
                 type: 'text',
-                text: `Available geographies for ${args.dataset}${args.year ? ` (${args.year})` : ''}:\n\n${JSON.stringify(parsedGeographyData, null, 2)}`,
+                text: flattenResponse(
+                  `Available geographies for ${args.dataset}${args.year ? ` (${args.year})` : ''}:`,
+                  parsedGeographyData
+                ),
               },
             ],
           }

--- a/mcp-server/src/tools/resolve-geography-fips.tool.ts
+++ b/mcp-server/src/tools/resolve-geography-fips.tool.ts
@@ -1,5 +1,6 @@
 import { Tool } from '@modelcontextprotocol/sdk/types.js'
 
+import { flattenResponse } from '../helpers/content-flattener.js'
 import { BaseTool } from './base.tool.js'
 import { DatabaseService } from '../services/database.service.js'
 import {
@@ -103,7 +104,10 @@ export class ResolveGeographyFipsTool extends BaseTool<ResolveGeographyFipsArgs>
           content: [
             {
               type: 'text',
-              text: `Found ${result.length} Matching Geographies:\n\n${JSON.stringify(result, null, 2)}`,
+              text: flattenResponse(
+                `Found ${result.length} Matching Geographies:`,
+                result
+              ),
             },
           ],
         }

--- a/mcp-server/src/tools/search-data-tables.tool.ts
+++ b/mcp-server/src/tools/search-data-tables.tool.ts
@@ -1,5 +1,6 @@
 import { Tool } from '@modelcontextprotocol/sdk/types.js'
 
+import { flattenResponse } from '../helpers/content-flattener.js'
 import { BaseTool } from './base.tool.js'
 import { DatabaseService } from '../services/database.service.js'
 import {
@@ -82,7 +83,10 @@ export class SearchDataTablesTool extends BaseTool<SearchDataTablesArgs> {
           content: [
             {
               type: 'text',
-              text: `Found ${results.length} Matching Data Table${results.length === 1 ? '' : 's'}:\n\n${JSON.stringify(results, null, 2)}`,
+              text: flattenResponse(
+                `Found ${results.length} Matching Data Table${results.length === 1 ? '' : 's'}:`,
+                results
+              ),
             },
           ],
         }


### PR DESCRIPTION
## Summary

ACS 1-year estimates are only available for geographic areas with populations of 65,000+. When users query smaller areas, the Census API returns a generic 400 error with no explanation — a common source of confusion.

This PR adds two improvements following the approach discussed by @luke-keller-census and @annav-gov:

### 1. Proactive guidance in tool description

Added a note to the `fetch-aggregate-data` tool description warning about the ACS 1-year population threshold and suggesting 5-year data as an alternative. This helps LLM agents avoid the error entirely.

### 2. Descriptive error message on 400

When a 400 error is returned for an ACS 1-year dataset, the error message now explains:
- The 65,000 population threshold
- Suggests using `acs/acs5` instead
- Links to the Census Bureau guidance page

**Before:**
```
Census API error: 400 Bad Request
```

**After:**
```
Census API error: 400 Bad Request. Note: ACS 1-year estimates (acs/acs1) are only
available for geographic areas with populations of 65,000 or more. If the requested
area has a smaller population, try using ACS 5-year estimates instead by changing the
dataset to "acs/acs5". See: https://www.census.gov/programs-surveys/acs/guidance/estimates.html
```

Fixes #35